### PR TITLE
Update hover widget styles across various color themes

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#8caaee",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#8caaee",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#eebebe",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#eebebe",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#a6d189",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#a6d189",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#babbf1",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#babbf1",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#ea999c",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#ea999c",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#ca9ee6",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#ca9ee6",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#ef9f76",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#ef9f76",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#f4b8e4",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#f4b8e4",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e78284",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#e78284",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#f2d5cf",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#f2d5cf",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#85c1dc",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#85c1dc",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#99d1db",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#99d1db",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#81c8be",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#81c8be",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e5c890",
     "editorGutter.foldingControlForeground": "#949cbb",
 
-    "editorHoverWidget.background": "#222532",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#2f3344",
+    "editorHoverWidget.statusBarBackground": "#2f3344",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c6d0f5",
+    "editorHoverWidget.highlightForeground": "#e5c890",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#1e66f5",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#1e66f5",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#dd7878",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#dd7878",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#40a02b",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#40a02b",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#7287fd",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#7287fd",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e64553",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#e64553",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#8839ef",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#8839ef",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#fe640b",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#fe640b",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#ea76cb",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#ea76cb",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#d20f39",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#d20f39",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#dc8a78",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#dc8a78",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#209fb5",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#209fb5",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#04a5e5",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#04a5e5",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#179299",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#179299",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#df8e1d",
     "editorGutter.foldingControlForeground": "#7c7f93",
 
-    "editorHoverWidget.background": "#d5d9e0",
+    "editorHoverWidget.background": "#e3e6ec",
+    "editorHoverWidget.statusBarBackground": "#e3e6ec",
     "editorHoverWidget.border": "#acb0be",
     "editorHoverWidget.foreground": "#4c4f69",
+    "editorHoverWidget.highlightForeground": "#df8e1d",
 
     "editorIndentGuide.activeBackground1": "#d5d9e0",
     "editorIndentGuide.background1": "#bcc0cc",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#83a5e7",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#83a5e7",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e4bcbc",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#e4bcbc",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#9fcf8f",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#9fcf8f",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#acb2e9",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#acb2e9",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e49399",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#e49399",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#bb97e7",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#bb97e7",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e69e78",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#e69e78",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e6b1d7",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#e6b1d7",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e0808e",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#e0808e",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e7d0cb",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#e7d0cb",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#79bbda",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#79bbda",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#89cbd6",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#89cbd6",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#85ccc1",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#85ccc1",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e0c896",
     "editorGutter.foldingControlForeground": "#939ab7",
 
-    "editorHoverWidget.background": "#171825",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#232638",
+    "editorHoverWidget.statusBarBackground": "#232638",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#c2cae9",
+    "editorHoverWidget.highlightForeground": "#e0c896",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#7fa6e6",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#7fa6e6",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e9c5c5",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#e9c5c5",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#99cf94",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#99cf94",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#a6afe9",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#a6afe9",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#d8939f",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#d8939f",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#ba9ae2",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#ba9ae2",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e2a37b",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#e2a37b",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e4b5d7",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#e4b5d7",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e4829e",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#e4829e",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e2cfcb",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#e2cfcb",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#70b7d8",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#70b7d8",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#80ccda",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#80ccda",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#8cd3c7",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#8cd3c7",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -189,9 +189,11 @@
     "editorGutter.commentGlyphForeground": "#e7d1a2",
     "editorGutter.foldingControlForeground": "#9399b2",
 
-    "editorHoverWidget.background": "#11111a",
-    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.background": "#1d1d2c",
+    "editorHoverWidget.statusBarBackground": "#1d1d2c",
+    "editorHoverWidget.border": "#585b70b6",
     "editorHoverWidget.foreground": "#aeb6cf",
+    "editorHoverWidget.highlightForeground": "#e7d1a2",
 
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",


### PR DESCRIPTION
- Changed the background color of the editor hover widget to a lighter shade for better visibility.
- Added a status bar background color for the editor hover widget to maintain consistency.
- Updated the highlight foreground color for the editor hover widget to match the respective theme colors.