### PR TITLE
feat: enhance theme colors for keywords and template expressions

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6db7c4",
+    "editorBracketHighlight.foreground2": "#7abedd",
+    "editorBracketHighlight.foreground3": "#98ca91",
+    "editorBracketHighlight.foreground4": "#d8c292",
+    "editorBracketHighlight.foreground5": "#e0a885",
+    "editorBracketHighlight.foreground6": "#c06e86",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6db7c4b0",
+    "editorBracketPairGuide.activeBackground2": "#7abeddb0",
+    "editorBracketPairGuide.activeBackground3": "#98ca91b0",
+    "editorBracketPairGuide.activeBackground4": "#d8c292b0",
+    "editorBracketPairGuide.activeBackground5": "#e0a885b0",
+    "editorBracketPairGuide.activeBackground6": "#c06e86b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a2abf8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8dbb77",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#4a5af0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#5d8849",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -115,19 +115,19 @@
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
 
-    "editorBracketHighlight.foreground1": "#6aafbb",
-    "editorBracketHighlight.foreground2": "#76b6d4",
-    "editorBracketHighlight.foreground3": "#90c08b",
-    "editorBracketHighlight.foreground4": "#d1bc8e",
-    "editorBracketHighlight.foreground5": "#d8a382",
-    "editorBracketHighlight.foreground6": "#bd6e84",
+    "editorBracketHighlight.foreground1": "#6cb3c0",
+    "editorBracketHighlight.foreground2": "#78b9d8",
+    "editorBracketHighlight.foreground3": "#93c48d",
+    "editorBracketHighlight.foreground4": "#d4bf90",
+    "editorBracketHighlight.foreground5": "#dba583",
+    "editorBracketHighlight.foreground6": "#be6e85",
 
-    "editorBracketPairGuide.activeBackground1": "#6aafbbb0",
-    "editorBracketPairGuide.activeBackground2": "#76b6d4b0",
-    "editorBracketPairGuide.activeBackground3": "#90c08bb0",
-    "editorBracketPairGuide.activeBackground4": "#d1bc8eb0",
-    "editorBracketPairGuide.activeBackground5": "#d8a382b0",
-    "editorBracketPairGuide.activeBackground6": "#bd6e84b0",
+    "editorBracketPairGuide.activeBackground1": "#6cb3c0b0",
+    "editorBracketPairGuide.activeBackground2": "#78b9d8b0",
+    "editorBracketPairGuide.activeBackground3": "#93c48db0",
+    "editorBracketPairGuide.activeBackground4": "#d4bf90b0",
+    "editorBracketPairGuide.activeBackground5": "#dba583b0",
+    "editorBracketPairGuide.activeBackground6": "#be6e85b0",
 
     "editorBracketHighlight.unexpectedBracket.foreground": "#da98a3",
 
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#a5adf1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#8bb677",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1064,6 +1065,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -963,6 +963,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
@@ -1061,6 +1062,18 @@
       "scope": ["constant.character.escape"],
       "settings": {
         "foreground": "#99a1f0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "string template expression",
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end"
+      ],
+      "settings": {
+        "foreground": "#89b177",
         "fontStyle": ""
       }
     },


### PR DESCRIPTION
- Added "keyword.control.flow" to the scope of keywords to improve syntax highlighting for control flow statements.
- Introduced a new color definition for string template expressions to enhance readability and visual appeal.
- Applied these changes across all Calmppuccin themes (Latte, Frappe, Macchiato, and Mocha) to ensure consistency.
- Updated bracket pair guide colors for the Frappe  and Macchiato themes to improve bracket matching visibility.