### PR TITLE
feat: refine semantic token highlighting for improved code clarity

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba6eb",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba6eb",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#8f4fe4",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#8f4fe4",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#bba8e6",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#bba8e6",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -942,6 +942,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1260,8 +1261,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1811,6 +1811,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -860,7 +860,7 @@
       }
     },
     {
-      "name": "keyword, storage",
+      "name": "keyword, storage, control",
       "scope": [
         "keyword.other.template",
         "keyword.other.substitution",
@@ -939,6 +939,7 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
+        "entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1257,8 +1258,7 @@
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
         "markup.raw.monospace",
-        "markup.mark",
-        "entity.name.type"
+        "markup.mark"
       ],
       "settings": {
         "foreground": "#6daf96"
@@ -1808,6 +1808,10 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
+      "foreground": "#b5a4dd",
+      "fontStyle": ""
+    },
+    "type": {
       "foreground": "#b5a4dd",
       "fontStyle": ""
     },


### PR DESCRIPTION
- Added `entity.name.type` to the scope of semantic token highlighting to ensure type names are properly styled.
- Introduced a new semantic token `type` to provide a dedicated style for type names, enhancing code readability.
- Applied these changes across all Calmppuccin themes (Latte, Frappe, Macchiato, and Mocha) to ensure consistency.