### PR TITLE
fix: improve semantic highlighting for types and annotations

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e9bcaa",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#c7926f",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#e2b8a8",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -943,6 +943,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1006,7 +1007,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1232,13 +1233,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -940,6 +940,7 @@
         "keyword.type.char",
         "keyword.type.void",
         "entity.name.type",
+        "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
@@ -1003,7 +1004,7 @@
     },
     {
       "name": "type parameter",
-      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter"],
+      "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
         "foreground": "#dfb7a7",
         "fontStyle": "italic"
@@ -1229,13 +1230,10 @@
         "constant.other.symbol.hashkey.ruby",
         "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby",
         "entity.name.type.annotation.kotlin",
-        "meta.type.parameters entity.name.type",
-        "meta.type.annotation entity.name.type",
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
-        "storage.type.powershell",
         "comment.block.documentation entity.name.type",
         "source.java storage.type",
         "source.groovy storage.type",


### PR DESCRIPTION
- Added `meta.type.annotation entity.name.type` to the scope of semantic token highlighting to ensure annotations are properly styled.
- Added `meta.type.parameters entity.name.type` to the scope of type parameters to ensure they are properly styled.
- Removed redundant scopes `meta.type.parameters entity.name.type`, `meta.type.annotation entity.name.type`, and `storage.type.powershell` from the generic rules to avoid conflicts.
- Applied these changes across all Calmppuccin themes (Latte, Frappe, Macchiato, and Mocha) to ensure consistency.