### PR TITLE
feat: improve highlighting and bump version to 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.3] - 2025-04-24
+
+- Updated the highlighting for type parameters. The new color now sits precisely between the keyword color and the parameter color
+- The function and method color has been made more prominent for dark themes to enhance visibility
+
 ## [1.1.2] - 2025-04-24
 
 - More granular highlighting for types (meta.type.parameters entity.name.type; meta.type.annotation entity.name.type)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Updated the highlighting for type parameters. The new color now sits precisely between the keyword color and the parameter color
- The function and method color has been made more prominent for dark themes to enhance visibility
- Updated version to 1.1.3