### PR TITLE
feat: improve event and delegate colors in themes

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#f1bc98",
     "symbolIcon.enumeratorForeground": "#a2abf8",
     "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a2abf8",
+    "symbolIcon.eventForeground": "#a8e0a0",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#a8e0a0",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a2abf8",
+      "foreground": "#a4e6c7",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8e0a0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#b0b4ef",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a2abf8",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a2abf8",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#c78356",
     "symbolIcon.enumeratorForeground": "#4a5af0",
     "symbolIcon.enumeratorMemberForeground": "#4a5af0",
-    "symbolIcon.eventForeground": "#4a5af0",
+    "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
     "symbolIcon.folderForeground": "#3fa091",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#8de652",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#4a5af0",
+      "foreground": "#52e67e",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#8de652",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#8270d2",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#4a5af0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#4a5af0",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#ecb998",
     "symbolIcon.enumeratorForeground": "#a5adf1",
     "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a5adf1",
+    "symbolIcon.eventForeground": "#a8dda1",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#a8dda1",
         "fontStyle": ""
       }
     },
@@ -1912,7 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a5adf1",
+      "foreground": "#a4e0c4",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dda1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1922,10 +1926,6 @@
     "typeParameter": {
       "foreground": "#acb4e0",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#a5adf1",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#a5adf1",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -495,7 +495,7 @@
     "symbolIcon.constructorForeground": "#e7b594",
     "symbolIcon.enumeratorForeground": "#99a1f0",
     "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#99a1f0",
+    "symbolIcon.eventForeground": "#a8dba1",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#a8dba1",
         "fontStyle": ""
       }
     },
@@ -1915,7 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#99a1f0",
+      "foreground": "#a1dbc0",
+      "fontStyle": ""
+    },
+    "event": {
+      "foreground": "#a8dba1",
       "fontStyle": ""
     },
     "parameter": {
@@ -1925,10 +1929,6 @@
     "typeParameter": {
       "foreground": "#A9B0DA",
       "fontStyle": "italic"
-    },
-    "event": {
-      "foreground": "#99a1f0",
-      "fontStyle": ""
     },
     "number": {
       "foreground": "#99a1f0",


### PR DESCRIPTION
This commit improves the color representation of events and delegates across all Calmppuccin themes. The event color has been changed to a more distinct green (`#8de652` in Latte, `#a8dba1` in Mocha, `#a8e0a0` in Frappe, and `#a8dda1` in Macchiato) for better visibility. The delegate color has been adjusted to a slightly different shade of green (`#52e67e` in Latte, `#a1dbc0` in Mocha, `#a4e6c7` in Frappe, and `#a4e0c4` in Macchiato) to visually differentiate it from events. These changes enhance the overall readability and aesthetics of the themes, making it easier to identify and distinguish events and delegates in the code.