### PR TITLE
feat: refine semantic and UI element colors

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#f1bc98",
+    "symbolIcon.classForeground": "#e6be90",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#f1bc98",
-    "symbolIcon.enumeratorForeground": "#a2abf8",
-    "symbolIcon.enumeratorMemberForeground": "#a2abf8",
-    "symbolIcon.eventForeground": "#a8e0a0",
+    "symbolIcon.constructorForeground": "#e6be90",
+    "symbolIcon.enumeratorForeground": "#e5a48a",
+    "symbolIcon.enumeratorMemberForeground": "#e5a48a",
+    "symbolIcon.eventForeground": "#a2e7c7",
     "symbolIcon.fieldForeground": "#e7abcd",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
     "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#ebd4a2",
+    "symbolIcon.interfaceForeground": "#e0cfa6",
     "symbolIcon.keyForeground": "#8dddd1",
     "symbolIcon.keywordForeground": "#bba6eb",
     "symbolIcon.methodForeground": "#7dbdee",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8dddd1",
     "symbolIcon.nullForeground": "#a2abf8",
     "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#f1bc98",
+    "symbolIcon.objectForeground": "#e6be90",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#e295eb",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#ee968f",
+    "symbolIcon.structForeground": "#e4988c",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#ee968f",
+        "foreground": "#e4988c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#e5a48a",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": "bold"
+        "foreground": "#e5a48a",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#ebd4a2",
+        "foreground": "#e0cfa6",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8e0a0",
+        "foreground": "#a2e7c7",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ee968f"
+        "foreground": "#e4988c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ebd4a2"
+        "foreground": "#e0cfa6"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#f1bc98"
+        "foreground": "#e6be90"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#f1bc98",
+        "foreground": "#e6be90",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#ee968f",
+      "foreground": "#e4988c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ebd4a2",
+      "foreground": "#e0cfa6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a2abf8",
+      "foreground": "#e5a48a",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a2abf8",
-      "fontStyle": "bold"
+      "foreground": "#e5a48a",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#e7abcd",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e6c7",
+      "foreground": "#6fa3e7",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8e0a0",
+      "foreground": "#a2e7c7",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#f1bc98",
+      "foreground": "#e6be90",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -73,9 +73,9 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#d5d9e0",
     "debugExceptionWidget.border": "#1e66f5",
-    "debugTokenExpression.number": "#4a5af0",
+    "debugTokenExpression.number": "#554af0",
     "debugTokenExpression.type": "#8f4fe4",
-    "debugTokenExpression.boolean": "#4a5af0",
+    "debugTokenExpression.boolean": "#554af0",
     "debugTokenExpression.string": "#4a996a",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -488,13 +488,13 @@
 
     "symbolIcon.textForeground": "#4c4f69",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#4a5af0",
-    "symbolIcon.classForeground": "#c78356",
+    "symbolIcon.booleanForeground": "#554af0",
+    "symbolIcon.classForeground": "#be7c3f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#4a5af0",
-    "symbolIcon.constructorForeground": "#c78356",
-    "symbolIcon.enumeratorForeground": "#4a5af0",
-    "symbolIcon.enumeratorMemberForeground": "#4a5af0",
+    "symbolIcon.constantForeground": "#554af0",
+    "symbolIcon.constructorForeground": "#be7c3f",
+    "symbolIcon.enumeratorForeground": "#a55e23",
+    "symbolIcon.enumeratorMemberForeground": "#a55e23",
     "symbolIcon.eventForeground": "#8de652",
     "symbolIcon.fieldForeground": "#b980a0",
     "symbolIcon.fileForeground": "#3fa091",
@@ -506,9 +506,9 @@
     "symbolIcon.methodForeground": "#428bc4",
     "symbolIcon.moduleForeground": "#3fa091",
     "symbolIcon.namespaceForeground": "#3fa091",
-    "symbolIcon.nullForeground": "#4a5af0",
-    "symbolIcon.numberForeground": "#4a5af0",
-    "symbolIcon.objectForeground": "#c78356",
+    "symbolIcon.nullForeground": "#554af0",
+    "symbolIcon.numberForeground": "#554af0",
+    "symbolIcon.objectForeground": "#be7c3f",
     "symbolIcon.operatorForeground": "#33a177",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#b265bb",
@@ -776,7 +776,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#a55e23",
         "fontStyle": ""
       }
     },
@@ -816,8 +816,8 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#4a5af0",
-        "fontStyle": "bold"
+        "foreground": "#a55e23",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1065,7 +1065,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1094,7 +1094,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1157,7 +1157,7 @@
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1515,7 +1515,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#c78356"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1598,7 +1598,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#4a5af0"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#c78356",
+        "foreground": "#be7c3f",
         "fontStyle": ""
       }
     },
@@ -1748,7 +1748,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#4a5af0",
+        "foreground": "#554af0",
         "fontStyle": "italic"
       }
     },
@@ -1840,19 +1840,19 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": ""
     },
     "struct": {
@@ -1868,12 +1868,12 @@
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#4a5af0",
+      "foreground": "#a55e23",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#4a5af0",
-      "fontStyle": "bold"
+      "foreground": "#a55e23",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#b980a0",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#52e67e",
+      "foreground": "#4a6ed1",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#8de652",
+      "foreground": "#439e69",
       "fontStyle": ""
     },
     "parameter": {
@@ -1928,7 +1928,7 @@
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "operator": {
@@ -1944,11 +1944,11 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "string": {
@@ -1960,7 +1960,7 @@
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": ""
     },
     "annotation": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#c78356",
+      "foreground": "#be7c3f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2016,15 +2016,15 @@
       "fontStyle": "italic"
     },
     "razorTransition": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirective": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#4a5af0",
+      "foreground": "#554af0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#ecb998",
+    "symbolIcon.classForeground": "#e2bd92",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#ecb998",
-    "symbolIcon.enumeratorForeground": "#a5adf1",
-    "symbolIcon.enumeratorMemberForeground": "#a5adf1",
-    "symbolIcon.eventForeground": "#a8dda1",
+    "symbolIcon.constructorForeground": "#e2bd92",
+    "symbolIcon.enumeratorForeground": "#e2a48b",
+    "symbolIcon.enumeratorMemberForeground": "#e2a48b",
+    "symbolIcon.eventForeground": "#d4c6a2",
     "symbolIcon.fieldForeground": "#daa4c3",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
     "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#e7d2a5",
+    "symbolIcon.interfaceForeground": "#dacaa4",
     "symbolIcon.keyForeground": "#8bd5ca",
     "symbolIcon.keywordForeground": "#bba8e6",
     "symbolIcon.methodForeground": "#81bdeb",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#8bd5ca",
     "symbolIcon.nullForeground": "#a5adf1",
     "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#ecb998",
+    "symbolIcon.objectForeground": "#e2bd92",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#da95e2",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e4948e",
+    "symbolIcon.structForeground": "#df978c",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -792,7 +792,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -800,7 +800,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4948e",
+        "foreground": "#df978c",
         "fontStyle": ""
       }
     },
@@ -808,7 +808,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#e2a48b",
         "fontStyle": ""
       }
     },
@@ -816,15 +816,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": "bold"
+        "foreground": "#e2a48b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e7d2a5",
+        "foreground": "#dacaa4",
         "fontStyle": ""
       }
     },
@@ -1015,7 +1015,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dda1",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1479,7 +1479,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1524,7 +1524,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4948e"
+        "foreground": "#df978c"
       }
     },
     {
@@ -1542,7 +1542,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7d2a5"
+        "foreground": "#dacaa4"
       }
     },
     {
@@ -1590,7 +1590,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#ecb998"
+        "foreground": "#e2bd92"
       }
     },
     {
@@ -1724,7 +1724,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#ecb998",
+        "foreground": "#e2bd92",
         "fontStyle": ""
       }
     },
@@ -1840,40 +1840,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4948e",
+      "foreground": "#df978c",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e7d2a5",
+      "foreground": "#dacaa4",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#a5adf1",
+      "foreground": "#e2a48b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#a5adf1",
-      "fontStyle": "bold"
+      "foreground": "#e2a48b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#daa4c3",
@@ -1912,11 +1912,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a4e0c4",
+      "foreground": "#71a3e6",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dda1",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "parameter": {
@@ -1976,7 +1976,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#ecb998",
+      "foreground": "#e2bd92",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -489,18 +489,18 @@
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
     "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e7b594",
+    "symbolIcon.classForeground": "#dfbc93",
     "symbolIcon.colorForeground": "#cfa0c2",
     "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e7b594",
-    "symbolIcon.enumeratorForeground": "#99a1f0",
-    "symbolIcon.enumeratorMemberForeground": "#99a1f0",
-    "symbolIcon.eventForeground": "#a8dba1",
+    "symbolIcon.constructorForeground": "#dfbc93",
+    "symbolIcon.enumeratorForeground": "#dda28b",
+    "symbolIcon.enumeratorMemberForeground": "#dda28b",
+    "symbolIcon.eventForeground": "#a1dbc0",
     "symbolIcon.fieldForeground": "#d39fbd",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
     "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#e6d0a2",
+    "symbolIcon.interfaceForeground": "#d4c6a2",
     "symbolIcon.keyForeground": "#81c2ba",
     "symbolIcon.keywordForeground": "#b5a4dd",
     "symbolIcon.methodForeground": "#82bbe7",
@@ -508,14 +508,14 @@
     "symbolIcon.namespaceForeground": "#81c2ba",
     "symbolIcon.nullForeground": "#99a1f0",
     "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e7b594",
+    "symbolIcon.objectForeground": "#dfbc93",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
     "symbolIcon.propertyForeground": "#d18fd8",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#da8882",
+    "symbolIcon.structForeground": "#da958b",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -795,7 +795,7 @@
       "name": "class",
       "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -803,7 +803,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#da8882",
+        "foreground": "#da958b",
         "fontStyle": ""
       }
     },
@@ -811,7 +811,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#dda28b",
         "fontStyle": ""
       }
     },
@@ -819,15 +819,15 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": "bold"
+        "foreground": "#dda28b",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface"],
       "settings": {
-        "foreground": "#e6d0a2",
+        "foreground": "#d4c6a2",
         "fontStyle": ""
       }
     },
@@ -1018,7 +1018,7 @@
       "name": "event",
       "scope": ["variable.other.event"],
       "settings": {
-        "foreground": "#a8dba1",
+        "foreground": "#a1dbc0",
         "fontStyle": ""
       }
     },
@@ -1482,7 +1482,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1527,7 +1527,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da8882"
+        "foreground": "#da958b"
       }
     },
     {
@@ -1545,7 +1545,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6d0a2"
+        "foreground": "#d4c6a2"
       }
     },
     {
@@ -1593,7 +1593,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e7b594"
+        "foreground": "#dfbc93"
       }
     },
     {
@@ -1727,7 +1727,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e7b594",
+        "foreground": "#dfbc93",
         "fontStyle": ""
       }
     },
@@ -1843,40 +1843,40 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#da8882",
+      "foreground": "#da958b",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e6d0a2",
+      "foreground": "#d4c6a2",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#99a1f0",
+      "foreground": "#dda28b",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#99a1f0",
-      "fontStyle": "bold"
+      "foreground": "#dda28b",
+      "fontStyle": "italic"
     },
     "field": {
       "foreground": "#d39fbd",
@@ -1915,11 +1915,11 @@
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#a1dbc0",
+      "foreground": "#71a2e2",
       "fontStyle": ""
     },
     "event": {
-      "foreground": "#a8dba1",
+      "foreground": "#a1dbc0",
       "fontStyle": ""
     },
     "parameter": {
@@ -1979,7 +1979,7 @@
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e7b594",
+      "foreground": "#dfbc93",
       "fontStyle": "italic"
     },
     "markupComment": {


### PR DESCRIPTION
This commit refines the color palette for semantic highlighting and UI elements within the Calmppuccin themes.