### PR TITLE
fix: Correct class scope and remove redundant variable object scope i…

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a2abf8",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#e7abcd",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#554af0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#b980a0",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -790,7 +790,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -1096,14 +1096,6 @@
       ],
       "settings": {
         "foreground": "#a5adf1",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#daa4c3",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -793,7 +793,7 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class", "entity.name.type.cs"],
+      "scope": ["variable.other.class", "entity.name.type.class", "variable.other.object"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -1099,14 +1099,6 @@
       ],
       "settings": {
         "foreground": "#99a1f0",
-        "fontStyle": ""
-      }
-    },
-    {
-      "name": "variable object",
-      "scope": ["variable.other.object"],
-      "settings": {
-        "foreground": "#d39fbd",
         "fontStyle": ""
       }
     },


### PR DESCRIPTION
…n themes

This commit addresses two issues in the Calmppuccin themes:

1.  **Corrected Class Scope:** The scope for "class" highlighting was updated in all themes (Latte, Frappe, Macchiato, and Mocha) to include `variable.other.object`. The original scope included `entity.name.type.cs`, which is specific to C#. The updated scope ensures that object variables are consistently highlighted as classes across different languages.

2.  **Removed Redundant Variable Object Scope:** The separate "variable object" scope was removed from all themes. This scope was redundant because the `variable.other.object` scope is now included in the "class" scope, providing the same highlighting without the need for a separate rule. This simplifies the theme definitions and avoids potential conflicts.