### PR TITLE
fix: Remove redundant ".cs" scopes from themes

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -783,7 +783,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -791,7 +791,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -836,7 +836,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1104,7 +1103,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1119,7 +1117,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -786,7 +786,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -794,7 +794,7 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace.cs"],
+      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -839,7 +839,6 @@
         "support.type.property-name",
         "support.type.vendored.property-name",
         "entity.name.function",
-        "entity.name.function.cs",
         "string.other.link",
         "markup.link",
         "support.type.vendored",
@@ -1107,7 +1106,6 @@
       "name": "field",
       "scope": [
         "entity.name.variable.field",
-        "entity.name.variable.field.cs",
         "variable.other.field",
         "variable.other.object.field",
         "text.xml entity.other.attribute-name"
@@ -1122,7 +1120,6 @@
       "scope": [
         "variable.other.object.property",
         "variable.object.property",
-        "variable.other.object.property.cs",
         "variable.other.property",
         "entity.name.variable.property",
         "meta.object-literal.key",


### PR DESCRIPTION
This commit removes the redundant ".cs" scopes from the calmppuccin themes. The ".cs" scopes were unnecessarily targeting C# specific scopes, while the base scopes are sufficient. This change ensures consistency and avoids potential conflicts with other language scopes.

entity.name.type.namespace works now for all languages.

The following scopes were removed:
- entity.name.type.namespace.cs
- entity.name.function.cs
- entity.name.variable.field.cs
- variable.other.object.property.cs