### PR TITLE
fix: Add keyword.other.directive to theme definitions

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -966,6 +966,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -969,6 +969,7 @@
         "source.apex storage.type",
         "source.nim storage.type",
         "source.elm storage.type",
+        "keyword.other.directive",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",


### PR DESCRIPTION
This commit adds the `keyword.other.directive` scope to the theme definitions for all Calmppuccin color themes. This ensures that preprocessor directives and similar keywords are properly styled in editors and IDEs that support this scope.