### PR TITLE
feat: Add keyword.other.directive to keyword scope and update version…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.3] - 2025-04-29
+
+- Added keyword.other.directive to the keyword scope
+
 ## [1.2.2] - 2025-04-29
 
 - Removed unnecessary ".cs" scopes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
… to 1.2.3

This commit adds the `keyword.other.directive` scope to the keyword scope in the theme, ensuring proper styling for preprocessor directives. It also updates the package version to 1.2.3 in `package.json` and `package-lock.json`, and adds a corresponding entry in `CHANGELOG.md`.