### PR TITLE
fix: Refactor theme scopes for improved consistency and accuracy

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bcc7e6",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e9c090",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba6eb",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#cca356"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#4c4f69",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#be7c3f",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#c79333"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4e0",
@@ -772,7 +771,10 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.others",
+        "constant.numeric",
         "constant.language",
+        "constant.language.boolean",
         "onstant.language.undefined",
         "constant.language.null"
       ],
@@ -790,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e6bf94",
         "fontStyle": ""
@@ -940,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -998,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#bba8e6",
@@ -1343,19 +1354,10 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
-        "foreground": "#c7a058"
+        "foreground": "#caa258"
       }
     },
     {

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -794,7 +793,13 @@
     },
     {
       "name": "class",
-      "scope": ["variable.other.class", "entity.name.type.class"],
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -714,12 +714,11 @@
         "meta.embedded.block variable punctuation.definition.variable.php",
         "string.quoted.double.class.other",
         "source.toml keyword",
-        "support.type.nim",
         "source.tf meta.template.expression",
         "source.scala entity.name.import",
         "markup.code",
         "markup.fenced_code.block",
-        "variable.other.object"
+        "entity.name"
       ],
       "settings": {
         "foreground": "#bbc4df",
@@ -793,8 +792,14 @@
       }
     },
     {
-      "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "name": "class",
+      "scope": [
+        "variable.other.object",
+        "variable.other.class",
+        "entity.name.type",
+        "entity.name.type.class",
+        "support.class"
+      ],
       "settings": {
         "foreground": "#e4bf96",
         "fontStyle": ""
@@ -943,7 +948,6 @@
         "keyword.type.byte",
         "keyword.type.char",
         "keyword.type.void",
-        "entity.name.type",
         "meta.type.annotation entity.name.type",
         "keyword.operator.expression.new",
         "variable.language.base",
@@ -1001,7 +1005,11 @@
         "keyword.control.default",
         "keyword.control.async",
         "keyword.control.await",
-        "keyword.control.context"
+        "keyword.control.context",
+        "support.type.sys-types",
+        "support.type",
+        "support.other.namespace",
+        "support.other.namespace.use"
       ],
       "settings": {
         "foreground": "#b5a4dd",
@@ -1346,17 +1354,8 @@
       }
     },
     {
-      "name": "Class, Support",
-      "scope": [
-        "entity.name",
-        "support.type",
-        "support.class",
-        "support.other.namespace.use.php",
-        "meta.use.php",
-        "support.other.namespace.php",
-        "markup.changed.git_gutter",
-        "support.type.sys-types"
-      ],
+      "name": "git-changed-gutter",
+      "scope": ["markup.changed.git_gutter"],
       "settings": {
         "foreground": "#c7a058"
       }


### PR DESCRIPTION
This commit refactors the theme scopes across all Calmppuccin themes to improve consistency and accuracy in syntax highlighting.

-   Removes `support.type.nim` from the general foreground scope as it's too specific.
-   Replaces `variable.other.object` in the general foreground scope with `entity.name` for broader coverage of entity names.
-   Consolidates class-related scopes under a single "class" name, including `variable.other.object`, `variable.other.class`, `entity.name.type`, `entity.name.type.class`, and `support.class`.
-   Removes `entity.name.type` from the keyword scope to avoid conflicts.
-   Adds several scopes to the keyword control scope for better highlighting of control flow elements, including `support.type.sys-types`, `support.type`, `support.other.namespace`, and `support.other.namespace.use`.
-   Renames the "Class, Support" scope to "git-changed-gutter" and narrows its scope to only `markup.changed.git_gutter`, and adjusts the color to match the intended purpose of highlighting git changes in the gutter.

These changes result in more accurate and consistent syntax highlighting across various languages and file types.