### PR TITLE
feat: Add keyword.local and keyword.control.lua to keyword scope, upd…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.5] - 2025-04-30
+
+- Added keyword.local and keyword.control.lua to the keyword scope
+
 ## [1.2.4] - 2025-04-29
 
 - Consolidated class-related scopes under a single "class" name, including variable.other.object, variable.other.class, entity.name.type, entity.name.type.class, and support.class

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
…ate version to 1.2.5

This commit adds `keyword.local` and `keyword.control.lua` to the keyword scope for improved Lua keyword highlighting and updates the package version to 1.2.5.

- Added `keyword.local` and `keyword.control.lua` to the keyword scope.
- Updated the package version to 1.2.5 in `package.json` and `package-lock.json`, and added a corresponding entry in `CHANGELOG.md`.