### PR TITLE
feat(themes): improve syntax highlighting and add italic attributes

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e4998f",
+    "symbolIcon.structForeground": "#e6978d",
     "symbolIcon.typeParameterForeground": "#b0b4ef",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e4998f",
+        "foreground": "#e6978d",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#e4d2a8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8dddd1",
+        "fontStyle": "italic",
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#e7abcd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#e7abcd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#e7abcd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e9c090"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a2abf8"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4998f"
+        "foreground": "#e6978d"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8dddd1",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#8dddd1",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8dddd1",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e4998f",
+      "foreground": "#e6978d",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#e7abcd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#e7abcd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#e7abcd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#e295eb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8dddd1",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#8c93b1",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#b980a0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#b980a0",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#b980a0"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#be7c3f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#3fa091",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#3fa091",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#3fa091",
       "fontStyle": ""
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#b980a0",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#b980a0",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#b980a0",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#b265bb",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#3fa091",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#7C7F93",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e0978e",
+    "symbolIcon.structForeground": "#e2988e",
     "symbolIcon.typeParameterForeground": "#acb4e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e0978e",
+        "foreground": "#e2988e",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#ddcfa8",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#daa4c3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#daa4c3",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#daa4c3"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e6bf94"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#a5adf1"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e0978e"
+        "foreground": "#e2988e"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#8bd5ca",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#73c9bf",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#8bd5ca",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e0978e",
+      "foreground": "#e2988e",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#daa4c3",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#daa4c3",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#daa4c3",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#da95e2",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#8bd5ca",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#898ea7",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -515,7 +515,7 @@
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
     "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#dd968d",
+    "symbolIcon.structForeground": "#db8781",
     "symbolIcon.typeParameterForeground": "#A9B0DA",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
@@ -674,11 +674,9 @@
         "string constant.other.placeholder",
         "variable.object",
         "support",
-        "entity.name.module",
         "meta.toc-list.id.html",
         "source.json meta.structure.dictionary.json support.type.property-name.json",
         "meta.var.clojure",
-        "source.java meta.class.body.java",
         "entity.name.package.go",
         "source.c",
         "source.cpp",
@@ -688,9 +686,6 @@
         "source.ruby",
         "source.coffee.embedded.source",
         "source.coffee",
-        "storage.modifier.import",
-        "storage.modifier.package",
-        "punctuation.definition.annotation",
         "source.groovy.embedded.source",
         "punctuation.definition.variable",
         "source.powershell",
@@ -758,7 +753,6 @@
         "source.reason constant.language.list",
         "support.variable.class.hideshow",
         "entity.other.attribute-name.class",
-        "meta.attribute.id entity.other.attribute-name",
         "text.html entity.other.attribute-name",
         "meta.tag.attributes entity.other.attribute-name",
         "source.cs entity.other.attribute-name",
@@ -773,6 +767,8 @@
         "constant.language.empty-list.haskell",
         "constant.language.unit.fsharp",
         "source.reason constant.language.unit",
+        "constant.other",
+        "constant.other.caps",
         "constant.others",
         "constant.numeric",
         "constant.language",
@@ -788,6 +784,14 @@
     {
       "name": "namespace",
       "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "module",
+      "scope": ["entity.name.module"],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -811,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#dd968d",
+        "foreground": "#db8781",
         "fontStyle": ""
       }
     },
@@ -833,7 +837,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
         "foreground": "#d8caa5",
         "fontStyle": ""
@@ -876,6 +880,12 @@
         "keyword.other.template",
         "keyword.other.substitution",
         "storage.modifier",
+        "storage.modifier.import",
+        "storage.modifier.package",
+        "storage.type.core.rust",
+        "storage.class.std.rust",
+        "entity.name.type.primitive",
+        "entity.name.lifetime.rust",
         "meta.tag.sgml",
         "constant.other.color",
         "entity.name.section",
@@ -901,7 +911,6 @@
         "source.kotlin storage.type.package",
         "constant.string.documentation.powershell",
         "punctuation.section.directive",
-        "punctuation.definition.attribute",
         "punctuation.definition.preprocessor",
         "punctuation.separator.namespace",
         "punctuation.separator.method",
@@ -919,7 +928,6 @@
         "variable.language.this",
         "variable.parameter.function.language.special",
         "variable.language.special.self.python",
-        "storage.modifier.java",
         "storage.type",
         "storage.type.type",
         "storage.type.modifier",
@@ -954,10 +962,9 @@
         "keyword.operator.expression.new",
         "variable.language.base",
         "variable.language.this",
+        "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
-        "storage.type.annotation",
-        "punctuation.definition.annotation",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -978,6 +985,7 @@
         "keyword.other.directive",
         "keyword.local",
         "keyword.control.lua",
+        "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
@@ -1108,6 +1116,7 @@
         "source.toml constant",
         "source.zig keyword.constant.bool",
         "source.zig keyword.constant.default",
+        "entity.name.type.numeric",
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
@@ -1243,16 +1252,12 @@
         "punctuation.definition.storage.type.objc",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
-        "source.java storage.type",
         "source.groovy storage.type",
-        "storage.type.r",
+        "storage.type.annotation",
+        "punctuation.definition.annotation",
         "source.haskell storage.type",
         "punctuation.separator.clause-head-body",
         "source.go storage.type",
-        "storage.type.core.rust",
-        "storage.class.std.rust",
-        "storage.modifier.lifetime.rust",
-        "entity.name.lifetime.rust",
         "support.type.vb",
         "support.type.julia",
         "constant.other.reference",
@@ -1268,7 +1273,8 @@
         "markup.mark"
       ],
       "settings": {
-        "foreground": "#6daf96"
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1394,9 +1400,22 @@
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name", "entity.other.attribute-name.pseudo-class"],
+      "scope": [
+        "entity.other.attribute-name",
+        "entity.other.attribute-name.pseudo-class",
+        "meta.attribute.id entity.other.attribute-name"
+      ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#d39fbd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "attributes italic",
+      "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
+      "settings": {
+        "foreground": "#d39fbd",
+        "fontStyle": "italic"
       }
     },
     {
@@ -1404,21 +1423,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#c5a873"
+        "foreground": "#d39fbd"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#d8ac5a"
+        "foreground": "#e4bf96"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#6a89ce"
+        "foreground": "#99a1f0"
       }
     },
     {
@@ -1522,7 +1541,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#dd968d"
+        "foreground": "#db8781"
       }
     },
     {
@@ -1833,6 +1852,10 @@
       "foreground": "#81c2ba",
       "fontStyle": ""
     },
+    "namespace.attribute": {
+      "foreground": "#71c2b8",
+      "fontStyle": "italic"
+    },
     "module": {
       "foreground": "#81c2ba",
       "fontStyle": ""
@@ -1854,11 +1877,11 @@
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#dd968d",
+      "foreground": "#db8781",
       "fontStyle": ""
     },
     "interface": {
@@ -1876,6 +1899,14 @@
     "field": {
       "foreground": "#d39fbd",
       "fontStyle": ""
+    },
+    "attribute": {
+      "foreground": "#d39fbd",
+      "fontStyle": ""
+    },
+    "attributeBracket": {
+      "foreground": "#d39fbd",
+      "fontStyle": "italic"
     },
     "property": {
       "foreground": "#d18fd8",
@@ -1963,7 +1994,7 @@
     },
     "annotation": {
       "foreground": "#81c2ba",
-      "fontStyle": ""
+      "fontStyle": "italic"
     },
     "comment": {
       "foreground": "#858aa0",


### PR DESCRIPTION
This commit improves syntax highlighting in all Calmppuccin themes by:

- Adding `constant.other` and `constant.other.caps` to the common foreground color.
- Adding a specific color for `entity.name.module`.
- Adding `entity.name.type.trait` to the interface scope.
- Adding more keywords for rust language.
- Adding `entity.name.type.numeric` to constants.
- Adding italic font style to annotations.
- Adding italic font style for certain attributes.
- Changing CSS classes color to better match the theme.
- Changing CSS ID's color to better match the theme.

These changes provide a more consistent and visually appealing coding experience.