### PR TITLE
feat: improve syntax highlighting for razor, markdown, other language…

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#8caaee",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1274,17 +1293,14 @@
       ],
       "settings": {
         "foreground": "#8dddd1",
-        "fontStyle": "italic",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#eebebe",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#a6d189",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#babbf1",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#ea999c",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#ca9ee6",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#ef9f76",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#f4b8e4",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#e78284",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#f2d5cf",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#85c1dc",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#99d1db",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#81c8be",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#222532",
     "debugExceptionWidget.border": "#e5c890",
-    "debugTokenExpression.number": "#a2abf8",
-    "debugTokenExpression.type": "#bba6eb",
-    "debugTokenExpression.boolean": "#a2abf8",
-    "debugTokenExpression.string": "#a6e7c0",
+    "debugTokenExpression.number": "#978cf5",
+    "debugTokenExpression.type": "#b5ade4",
+    "debugTokenExpression.boolean": "#978cf5",
+    "debugTokenExpression.string": "#ade6a7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c6d0f5",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a2abf8",
-    "symbolIcon.classForeground": "#e9c090",
+    "symbolIcon.booleanForeground": "#978cf5",
+    "symbolIcon.classForeground": "#ecb38f",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a2abf8",
-    "symbolIcon.constructorForeground": "#e9c090",
-    "symbolIcon.enumeratorForeground": "#e9a68b",
-    "symbolIcon.enumeratorMemberForeground": "#e9a68b",
+    "symbolIcon.constantForeground": "#978cf5",
+    "symbolIcon.constructorForeground": "#ecb38f",
+    "symbolIcon.enumeratorForeground": "#e69fab",
+    "symbolIcon.enumeratorMemberForeground": "#e69fab",
     "symbolIcon.eventForeground": "#a2e7c7",
-    "symbolIcon.fieldForeground": "#e7abcd",
+    "symbolIcon.fieldForeground": "#e6b3d6",
     "symbolIcon.fileForeground": "#8dddd1",
     "symbolIcon.folderForeground": "#8dddd1",
-    "symbolIcon.functionForeground": "#7dbdee",
-    "symbolIcon.interfaceForeground": "#e4d2a8",
+    "symbolIcon.functionForeground": "#8cb2ee",
+    "symbolIcon.interfaceForeground": "#e6d6ad",
     "symbolIcon.keyForeground": "#8dddd1",
-    "symbolIcon.keywordForeground": "#bba6eb",
-    "symbolIcon.methodForeground": "#7dbdee",
+    "symbolIcon.keywordForeground": "#b5ade4",
+    "symbolIcon.methodForeground": "#8cb2ee",
     "symbolIcon.moduleForeground": "#8dddd1",
     "symbolIcon.namespaceForeground": "#8dddd1",
-    "symbolIcon.nullForeground": "#a2abf8",
-    "symbolIcon.numberForeground": "#a2abf8",
-    "symbolIcon.objectForeground": "#e9c090",
+    "symbolIcon.nullForeground": "#978cf5",
+    "symbolIcon.numberForeground": "#978cf5",
+    "symbolIcon.objectForeground": "#ecb38f",
     "symbolIcon.operatorForeground": "#98e6c8",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#e295eb",
+    "symbolIcon.propertyForeground": "#c19dee",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a6e7c0",
-    "symbolIcon.structForeground": "#e6978d",
-    "symbolIcon.typeParameterForeground": "#b0b4ef",
+    "symbolIcon.stringForeground": "#ade6a7",
+    "symbolIcon.structForeground": "#eb8da8",
+    "symbolIcon.typeParameterForeground": "#abbbe5",
     "symbolIcon.unitForeground": "#98e6c8",
     "symbolIcon.variableForeground": "#bcc7e6",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#a5c2f3",
+        "foreground": "#a1c9e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e6978d",
+        "foreground": "#eb8da8",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e9a68b",
+        "foreground": "#e69fab",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#e4d2a8",
+        "foreground": "#e6d6ad",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#7dbdee",
+        "foreground": "#8cb2ee",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#b0b4ef",
+        "foreground": "#abbbe5",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#e295ebe0",
+        "foreground": "#c19deee0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#8c93b1",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8dddd1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a2abf8",
-        "fontStyle": ""
+        "foreground": "#8dddd1",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba6eb"
+        "foreground": "#b5ade4"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#8cb2ee"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#7dbdee"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e7abcd"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a2abf8"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e6978d"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e295eb"
+        "foreground": "#eb8da8"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e4d2a8"
+        "foreground": "#e6d6ad"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c9d8b2"
+        "foreground": "#a0dbe9"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e9c090"
+        "foreground": "#ecb38f"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a2abf8"
+        "foreground": "#978cf5"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#e7abcd"
+        "foreground": "#e6b3d6"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#e295eb"
+        "foreground": "#c19dee"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e9c090",
+        "foreground": "#ecb38f",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#e295eb",
+        "foreground": "#c19dee",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a2abf8",
+        "foreground": "#978cf5",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#e7abcd",
+        "foreground": "#e6b3d6",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba6eb",
+        "foreground": "#b5ade4",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a6e7c0",
+        "foreground": "#ade6a7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c9d8b2",
+        "foreground": "#a0dbe9",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e6978d",
+      "foreground": "#eb8da8",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#e4d2a8",
+      "foreground": "#e6d6ad",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e9a68b",
+      "foreground": "#e69fab",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#e295eb",
+      "foreground": "#c19dee",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#e295ebe0",
+      "foreground": "#c19deee0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#e295eb",
+      "foreground": "#bf9bec",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#6fa3e7",
+      "foreground": "#79a5ec",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#a5c2f3",
+      "foreground": "#a1c9e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#b0b4ef",
+      "foreground": "#abbbe5",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#7dbdee",
+      "foreground": "#8cb2ee",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a2abf8",
+      "foreground": "#978cf5",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a2abf8",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c9d8b2",
+      "foreground": "#a0dbe9",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e9c090",
+      "foreground": "#ecb38f",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a2abf8",
+    "razorCommentTransition": {
+      "foreground": "#8c93b1",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#8c93b1",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8dddd1",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a2abf8",
+      "foreground": "#8dddd1",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a2abf8",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba6eb",
+      "foreground": "#b5ade4",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#e7abcd",
+      "foreground": "#e6b3d6",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a6e7c0",
+      "foreground": "#ade6a7",
       "fontStyle": "italic"
     }
   }

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -1161,34 +1161,53 @@
       }
     },
     {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#7C7F93",
+        "fontStyle": "italic"
+      }
+    },
+    {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#3fa091",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#554af0",
-        "fontStyle": ""
+        "foreground": "#3fa091",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#be7c3f"
+        "foreground": "#428bc4"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#428bc4"
+        "foreground": "#b265bb"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b980a0"
+        "foreground": "#be7c3f"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#b980a0"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#554af0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d35950"
+        "foreground": "#554af0"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#b265bb"
+        "foreground": "#d35950"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#667e42"
+        "foreground": "#2fb0e4"
       }
     },
     {
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#667e42",
+        "foreground": "#2fb0e4",
         "fontStyle": ""
       }
     }
@@ -2001,7 +2017,7 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#667e42",
+      "foreground": "#2fb0e4",
       "fontStyle": ""
     },
     "regexCharacterClass": {
@@ -2044,16 +2060,24 @@
       "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#554af0",
+    "razorCommentTransition": {
+      "foreground": "#7C7F93",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#7C7F93",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#3fa091",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#554af0",
+      "foreground": "#3fa091",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#554af0",
+      "foreground": "#b980a0",
       "fontStyle": "italic"
     },
     "razorComponentElement": {

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#83a5e7",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#e4bcbc",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#9fcf8f",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#acb2e9",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#e49399",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#bb97e7",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#e69e78",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#e6b1d7",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#e0808e",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#e7d0cb",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#79bbda",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#89cbd6",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#85ccc1",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#171825",
     "debugExceptionWidget.border": "#e0c896",
-    "debugTokenExpression.number": "#a5adf1",
-    "debugTokenExpression.type": "#bba8e6",
-    "debugTokenExpression.boolean": "#a5adf1",
-    "debugTokenExpression.string": "#a8e2bf",
+    "debugTokenExpression.number": "#958bec",
+    "debugTokenExpression.type": "#b4ade0",
+    "debugTokenExpression.boolean": "#958bec",
+    "debugTokenExpression.string": "#addfa7",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#c2cae9",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#a5adf1",
-    "symbolIcon.classForeground": "#e6bf94",
+    "symbolIcon.booleanForeground": "#958bec",
+    "symbolIcon.classForeground": "#e7b291",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#a5adf1",
-    "symbolIcon.constructorForeground": "#e6bf94",
-    "symbolIcon.enumeratorForeground": "#e6a68d",
-    "symbolIcon.enumeratorMemberForeground": "#e6a68d",
+    "symbolIcon.constantForeground": "#958bec",
+    "symbolIcon.constructorForeground": "#e7b291",
+    "symbolIcon.enumeratorForeground": "#e09ea9",
+    "symbolIcon.enumeratorMemberForeground": "#e09ea9",
     "symbolIcon.eventForeground": "#a3e0c4",
-    "symbolIcon.fieldForeground": "#daa4c3",
+    "symbolIcon.fieldForeground": "#dfb1d1",
     "symbolIcon.fileForeground": "#8bd5ca",
     "symbolIcon.folderForeground": "#8bd5ca",
-    "symbolIcon.functionForeground": "#81bdeb",
-    "symbolIcon.interfaceForeground": "#ddcfa8",
+    "symbolIcon.functionForeground": "#8eb2eb",
+    "symbolIcon.interfaceForeground": "#e0d2aa",
     "symbolIcon.keyForeground": "#8bd5ca",
-    "symbolIcon.keywordForeground": "#bba8e6",
-    "symbolIcon.methodForeground": "#81bdeb",
+    "symbolIcon.keywordForeground": "#b4ade0",
+    "symbolIcon.methodForeground": "#8eb2eb",
     "symbolIcon.moduleForeground": "#8bd5ca",
     "symbolIcon.namespaceForeground": "#8bd5ca",
-    "symbolIcon.nullForeground": "#a5adf1",
-    "symbolIcon.numberForeground": "#a5adf1",
-    "symbolIcon.objectForeground": "#e6bf94",
+    "symbolIcon.nullForeground": "#958bec",
+    "symbolIcon.numberForeground": "#958bec",
+    "symbolIcon.objectForeground": "#e7b291",
     "symbolIcon.operatorForeground": "#98dfc4",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#da95e2",
+    "symbolIcon.propertyForeground": "#bd9ae7",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a8e2bf",
-    "symbolIcon.structForeground": "#e2988e",
-    "symbolIcon.typeParameterForeground": "#acb4e0",
+    "symbolIcon.stringForeground": "#addfa7",
+    "symbolIcon.structForeground": "#e78ea7",
+    "symbolIcon.typeParameterForeground": "#aab9e0",
     "symbolIcon.unitForeground": "#98dfc4",
     "symbolIcon.variableForeground": "#bbc4e0",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dc1db",
+        "foreground": "#9fc5e0",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#e2988e",
+        "foreground": "#e78ea7",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e6a68d",
+        "foreground": "#e09ea9",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#ddcfa8",
+        "foreground": "#e0d2aa",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#81bdeb",
+        "foreground": "#8eb2eb",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#acb4e0",
+        "foreground": "#aab9e0",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#da95e2e0",
+        "foreground": "#bd9ae7e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#898ea7",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#a5adf1",
-        "fontStyle": ""
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#bba8e6"
+        "foreground": "#b4ade0"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#8eb2eb"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#81bdeb"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#daa4c3"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#a5adf1"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#e2988e"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#da95e2"
+        "foreground": "#e78ea7"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#ddcfa8"
+        "foreground": "#e0d2aa"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c6d3b1"
+        "foreground": "#a0d6e2"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e6bf94"
+        "foreground": "#e7b291"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#a5adf1"
+        "foreground": "#958bec"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#daa4c3"
+        "foreground": "#dfb1d1"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#da95e2"
+        "foreground": "#bd9ae7"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e6bf94",
+        "foreground": "#e7b291",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#da95e2",
+        "foreground": "#bd9ae7",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#a5adf1",
+        "foreground": "#958bec",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#daa4c3",
+        "foreground": "#dfb1d1",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#bba8e6",
+        "foreground": "#b4ade0",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a8e2bf",
+        "foreground": "#addfa7",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c6d3b1",
+        "foreground": "#a0d6e2",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#e2988e",
+      "foreground": "#e78ea7",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#ddcfa8",
+      "foreground": "#e0d2aa",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e6a68d",
+      "foreground": "#e09ea9",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#da95e2e0",
+      "foreground": "#bd9ae7e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#da95e2",
+      "foreground": "#bd9ae7",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a3e6",
+      "foreground": "#78a2e6",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dc1db",
+      "foreground": "#9fc5e0",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#acb4e0",
+      "foreground": "#aab9e0",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#81bdeb",
+      "foreground": "#8eb2eb",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#a5adf1",
+      "foreground": "#958bec",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c6d3b1",
+      "foreground": "#a0d6e2",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e6bf94",
+      "foreground": "#e7b291",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#898ea7",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#a5adf1",
+    "razorCommentTransition": {
+      "foreground": "#898ea7",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#898ea7",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#8bd5ca",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#a5adf1",
+      "foreground": "#8bd5ca",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#a5adf1",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#bba8e6",
+      "foreground": "#b4ade0",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#daa4c3",
+      "foreground": "#dfb1d1",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a8e2bf",
+      "foreground": "#addfa7",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#7fa6e6",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#e9c5c5",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#99cf94",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#a6afe9",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#d8939f",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#ba9ae2",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#e2a37b",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#e4b5d7",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#e4829e",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#e2cfcb",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#70b7d8",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#80ccda",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#8cd3c7",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -73,10 +73,10 @@
     "debugToolBar.border": "#00000000",
     "debugExceptionWidget.background": "#11111a",
     "debugExceptionWidget.border": "#e7d1a2",
-    "debugTokenExpression.number": "#99a1f0",
-    "debugTokenExpression.type": "#b5a4dd",
-    "debugTokenExpression.boolean": "#99a1f0",
-    "debugTokenExpression.string": "#a4dbba",
+    "debugTokenExpression.number": "#978deb",
+    "debugTokenExpression.type": "#b3acdd",
+    "debugTokenExpression.boolean": "#978deb",
+    "debugTokenExpression.string": "#addaa8",
     "debugTokenExpression.error": "#d47b95",
     "debugIcon.breakpointForeground": "#d47b95",
     "debugIcon.breakpointDisabledForeground": "#d47b9599",
@@ -488,35 +488,35 @@
 
     "symbolIcon.textForeground": "#aeb6cf",
     "symbolIcon.arrayForeground": "#e2a47d",
-    "symbolIcon.booleanForeground": "#99a1f0",
-    "symbolIcon.classForeground": "#e4bf96",
+    "symbolIcon.booleanForeground": "#978deb",
+    "symbolIcon.classForeground": "#e0af90",
     "symbolIcon.colorForeground": "#cfa0c2",
-    "symbolIcon.constantForeground": "#99a1f0",
-    "symbolIcon.constructorForeground": "#e4bf96",
-    "symbolIcon.enumeratorForeground": "#e2a78f",
-    "symbolIcon.enumeratorMemberForeground": "#e2a78f",
+    "symbolIcon.constantForeground": "#978deb",
+    "symbolIcon.constructorForeground": "#e0af90",
+    "symbolIcon.enumeratorForeground": "#da9ba6",
+    "symbolIcon.enumeratorMemberForeground": "#da9ba6",
     "symbolIcon.eventForeground": "#a1dbc0",
-    "symbolIcon.fieldForeground": "#d39fbd",
+    "symbolIcon.fieldForeground": "#d8afcc",
     "symbolIcon.fileForeground": "#81c2ba",
     "symbolIcon.folderForeground": "#81c2ba",
-    "symbolIcon.functionForeground": "#82bbe7",
-    "symbolIcon.interfaceForeground": "#d8caa5",
+    "symbolIcon.functionForeground": "#8fb1e7",
+    "symbolIcon.interfaceForeground": "#e7d3a6",
     "symbolIcon.keyForeground": "#81c2ba",
-    "symbolIcon.keywordForeground": "#b5a4dd",
-    "symbolIcon.methodForeground": "#82bbe7",
+    "symbolIcon.keywordForeground": "#b3acdd",
+    "symbolIcon.methodForeground": "#8fb1e7",
     "symbolIcon.moduleForeground": "#81c2ba",
     "symbolIcon.namespaceForeground": "#81c2ba",
-    "symbolIcon.nullForeground": "#99a1f0",
-    "symbolIcon.numberForeground": "#99a1f0",
-    "symbolIcon.objectForeground": "#e4bf96",
+    "symbolIcon.nullForeground": "#978deb",
+    "symbolIcon.numberForeground": "#978deb",
+    "symbolIcon.objectForeground": "#e0af90",
     "symbolIcon.operatorForeground": "#96dbc1",
     "symbolIcon.packageForeground": "#f2cdcd",
-    "symbolIcon.propertyForeground": "#d18fd8",
+    "symbolIcon.propertyForeground": "#ba9be0",
     "symbolIcon.referenceForeground": "#d6c08f",
     "symbolIcon.snippetForeground": "#f2cdcd",
-    "symbolIcon.stringForeground": "#a4dbba",
-    "symbolIcon.structForeground": "#db8781",
-    "symbolIcon.typeParameterForeground": "#A9B0DA",
+    "symbolIcon.stringForeground": "#addaa8",
+    "symbolIcon.structForeground": "#e48da6",
+    "symbolIcon.typeParameterForeground": "#aeb6e2",
     "symbolIcon.unitForeground": "#96dbc1",
     "symbolIcon.variableForeground": "#bbc4df",
 
@@ -726,7 +726,7 @@
       "name": "parameter",
       "scope": ["entity.name.variable.parameter", "variable.parameter", "variable.import.parameter"],
       "settings": {
-        "foreground": "#9dbdd6",
+        "foreground": "#a8c1e6",
         "fontStyle": "italic"
       }
     },
@@ -777,7 +777,7 @@
         "constant.language.null"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -807,7 +807,7 @@
         "support.class"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -815,7 +815,7 @@
       "name": "struct",
       "scope": ["variable.other.struct", "entity.name.type.struct"],
       "settings": {
-        "foreground": "#db8781",
+        "foreground": "#e48da6",
         "fontStyle": ""
       }
     },
@@ -823,7 +823,7 @@
       "name": "enum",
       "scope": ["variable.other.enum", "entity.name.type.enum"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": ""
       }
     },
@@ -831,7 +831,7 @@
       "name": "enum member",
       "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
       "settings": {
-        "foreground": "#e2a78f",
+        "foreground": "#da9ba6",
         "fontStyle": "italic"
       }
     },
@@ -839,7 +839,7 @@
       "name": "interface",
       "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
       "settings": {
-        "foreground": "#d8caa5",
+        "foreground": "#e7d3a6",
         "fontStyle": ""
       }
     },
@@ -870,7 +870,7 @@
         "support.function.construct."
       ],
       "settings": {
-        "foreground": "#82bbe7",
+        "foreground": "#8fb1e7",
         "fontStyle": ""
       }
     },
@@ -1024,7 +1024,7 @@
         "support.other.namespace.use"
       ],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1032,7 +1032,7 @@
       "name": "type parameter",
       "scope": ["entity.name.type.type-parameter", "variable.type.type-parameter", "meta.type.parameters entity.name.type"],
       "settings": {
-        "foreground": "#A9B0DA",
+        "foreground": "#aeb6e2",
         "fontStyle": "italic"
       }
     },
@@ -1059,7 +1059,7 @@
         "string.quoted.double"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1082,7 +1082,7 @@
         "storage.type.string"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1090,7 +1090,7 @@
       "name": "string escape",
       "scope": ["constant.character.escape"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1120,7 +1120,7 @@
         "entity.other.keyframe-offset.percentage"
       ],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": ""
       }
     },
@@ -1133,7 +1133,7 @@
         "text.xml entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1148,7 +1148,7 @@
         "support.variable.property"
       ],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1156,39 +1156,58 @@
       "name": "property readonly",
       "scope": ["variable.other.constant.property"],
       "settings": {
-        "foreground": "#d18fd8e0",
+        "foreground": "#ba9be0e0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "razor comment",
+      "scope": [
+        "keyword.control.razor.comment",
+        "keyword.control.razor.comment.star",
+        "meta.comment.razor keyword.control.cshtml.transition"
+      ],
+      "settings": {
+        "foreground": "#858aa0",
         "fontStyle": "italic"
       }
     },
     {
       "name": "razor directive",
+      "scope": ["keyword.control.cshtml.transition"],
+      "settings": {
+        "foreground": "#81c2ba",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "razor directive italic",
       "scope": [
         "keyword.control.razor.directive",
+        "keyword.control.razor.directive.page",
+        "keyword.control.razor.directive.inherits",
         "keyword.control.razor.directive.code",
-        "keyword.control.razor.comment.star",
-        "keyword.control.cshtml.transition",
-        "keyword.control.cshtml",
         "keyword.control.razor.directive.codeblock",
         "keyword.control.razor.directive.codeblock.open",
         "keyword.control.razor.directive.codeblock.close"
       ],
       "settings": {
-        "foreground": "#99a1f0",
-        "fontStyle": ""
+        "foreground": "#81c2ba",
+        "fontStyle": "italic"
       }
     },
     {
       "name": "Colors",
       "scope": ["constant.other.color"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
       "name": "Meta selector",
       "scope": ["meta.selector"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1280,11 +1299,8 @@
     {
       "name": "support",
       "scope": [
-        "entity.name",
         "entity.other",
-        "support.orther.namespace.use.php",
         "meta.use.php",
-        "support.other.namespace.php",
         "support.type",
         "support.class",
         "punctuation.definition.parameters",
@@ -1308,7 +1324,7 @@
         "support.variable"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1360,7 +1376,7 @@
         "source.zig keyword.structure"
       ],
       "settings": {
-        "foreground": "#b5a4dd"
+        "foreground": "#b3acdd"
       }
     },
     {
@@ -1388,7 +1404,7 @@
         "source.postcss support.type.property-name"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1406,7 +1422,7 @@
         "meta.attribute.id entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1414,7 +1430,7 @@
       "name": "attributes italic",
       "scope": ["punctuation.definition.attribute", "meta.attribute.rust"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": "italic"
       }
     },
@@ -1423,21 +1439,21 @@
       "scope": ["text.html.basic entity.other.attribute-name.html", "text.html.basic entity.other.attribute-name"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
       "name": "CSS Classes",
       "scope": ["entity.other.attribute-name.class"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
       "name": "CSS ID's",
       "scope": ["source.sass keyword.control"],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1496,7 +1512,7 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#8fb1e7"
       }
     },
     {
@@ -1505,7 +1521,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#82bbe7"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1514,7 +1530,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d39fbd"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1523,7 +1539,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#cf8799"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1532,7 +1548,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#99a1f0"
+        "foreground": "#cf8799"
       }
     },
     {
@@ -1541,7 +1557,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#db8781"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1550,7 +1566,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d18fd8"
+        "foreground": "#e48da6"
       }
     },
     {
@@ -1559,7 +1575,7 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "#d8caa5"
+        "foreground": "#e7d3a6"
       }
     },
     {
@@ -1575,7 +1591,7 @@
       "name": "Markdown - Plain",
       "scope": ["text.html.markdown", "punctuation.definition.list_item.markdown", "meta.paragraph.markdown"],
       "settings": {
-        "foreground": "#c0ccad"
+        "foreground": "#a1d4df"
       }
     },
     {
@@ -1607,7 +1623,7 @@
       "name": "Markdown - Section",
       "scope": ["entity.name.section.markdown"],
       "settings": {
-        "foreground": "#e4bf96"
+        "foreground": "#e0af90"
       }
     },
     {
@@ -1615,7 +1631,7 @@
       "scope": ["markup.italic"],
       "settings": {
         "fontStyle": "italic",
-        "foreground": "#99a1f0"
+        "foreground": "#978deb"
       }
     },
     {
@@ -1623,7 +1639,7 @@
       "scope": ["markup.bold", "markup.bold string"],
       "settings": {
         "fontStyle": "bold",
-        "foreground": "#d39fbd"
+        "foreground": "#d8afcc"
       }
     },
     {
@@ -1638,7 +1654,7 @@
       ],
       "settings": {
         "fontStyle": "italic bold",
-        "foreground": "#d18fd8"
+        "foreground": "#ba9be0"
       }
     },
     {
@@ -1741,7 +1757,7 @@
         "entity.other.attribute-name.class.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#e4bf96",
+        "foreground": "#e0af90",
         "fontStyle": ""
       }
     },
@@ -1757,7 +1773,7 @@
       "name": "css property name",
       "scope": ["support.type.property-name.css"],
       "settings": {
-        "foreground": "#d18fd8",
+        "foreground": "#ba9be0",
         "fontStyle": ""
       }
     },
@@ -1765,7 +1781,7 @@
       "name": "css property value",
       "scope": ["meta.property-value", "support.constant.property-value.css"],
       "settings": {
-        "foreground": "#99a1f0",
+        "foreground": "#978deb",
         "fontStyle": "italic"
       }
     },
@@ -1789,7 +1805,7 @@
       "name": "html attribute name",
       "scope": ["entity.other.attribute-name.html"],
       "settings": {
-        "foreground": "#d39fbd",
+        "foreground": "#d8afcc",
         "fontStyle": ""
       }
     },
@@ -1797,7 +1813,7 @@
       "name": "html markup element",
       "scope": ["entity.name.tag.html"],
       "settings": {
-        "foreground": "#b5a4dd",
+        "foreground": "#b3acdd",
         "fontStyle": ""
       }
     },
@@ -1809,7 +1825,7 @@
         "punctuation.definition.string.end.html"
       ],
       "settings": {
-        "foreground": "#a4dbba",
+        "foreground": "#addaa8",
         "fontStyle": ""
       }
     },
@@ -1817,7 +1833,7 @@
       "name": "text",
       "scope": ["text"],
       "settings": {
-        "foreground": "#c0ccad",
+        "foreground": "#a1d4df",
         "fontStyle": ""
       }
     }
@@ -1825,27 +1841,27 @@
   "semanticHighlighting": true,
   "semanticTokenColors": {
     "selfKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "type": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "controlKeyword": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "macro": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "selfParameter": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "newOperator": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "namespace": {
@@ -1861,87 +1877,87 @@
       "fontStyle": ""
     },
     "class": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "class.defaultLibrary": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "recordClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "record": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": ""
     },
     "struct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "recordStruct": {
-      "foreground": "#db8781",
+      "foreground": "#e48da6",
       "fontStyle": ""
     },
     "interface": {
-      "foreground": "#d8caa5",
+      "foreground": "#e7d3a6",
       "fontStyle": ""
     },
     "enum": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": ""
     },
     "enumMember": {
-      "foreground": "#e2a78f",
+      "foreground": "#da9ba6",
       "fontStyle": "italic"
     },
     "field": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "attributeBracket": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "property": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "property.readonly": {
-      "foreground": "#d18fd8e0",
+      "foreground": "#ba9be0e0",
       "fontStyle": "italic"
     },
     "recordComponent": {
-      "foreground": "#d18fd8",
+      "foreground": "#ba9be0",
       "fontStyle": ""
     },
     "function": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "function.defaultLibrary": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "method": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "extensionMethod": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "italic"
     },
     "*.async": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": ""
     },
     "delegate": {
-      "foreground": "#71a2e2",
+      "foreground": "#77a0e2",
       "fontStyle": ""
     },
     "event": {
@@ -1949,15 +1965,15 @@
       "fontStyle": ""
     },
     "parameter": {
-      "foreground": "#9dbdd6",
+      "foreground": "#a8c1e6",
       "fontStyle": "italic"
     },
     "typeParameter": {
-      "foreground": "#A9B0DA",
+      "foreground": "#aeb6e2",
       "fontStyle": "italic"
     },
     "number": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "operator": {
@@ -1965,7 +1981,7 @@
       "fontStyle": ""
     },
     "operatorOverload": {
-      "foreground": "#82bbe7",
+      "foreground": "#8fb1e7",
       "fontStyle": "bold"
     },
     "punctuation": {
@@ -1973,23 +1989,23 @@
       "fontStyle": ""
     },
     "constant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "builtinConstant": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "string": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "stringVerbatim": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "stringEscapeCharacter": {
-      "foreground": "#99a1f0",
+      "foreground": "#978deb",
       "fontStyle": ""
     },
     "annotation": {
@@ -2001,11 +2017,11 @@
       "fontStyle": "italic"
     },
     "text": {
-      "foreground": "#c0ccad",
+      "foreground": "#a1d4df",
       "fontStyle": ""
     },
     "regexCharacterClass": {
-      "foreground": "#e4bf96",
+      "foreground": "#e0af90",
       "fontStyle": "italic"
     },
     "markupComment": {
@@ -2025,59 +2041,67 @@
       "fontStyle": ""
     },
     "markupElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "markupAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markupAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "markupAttributeQuote": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": ""
     },
     "razorComment": {
       "foreground": "#858aa0",
       "fontStyle": "italic"
     },
-    "razorTransition": {
-      "foreground": "#99a1f0",
+    "razorCommentTransition": {
+      "foreground": "#858aa0",
       "fontStyle": "italic"
     },
+    "razorCommentStar": {
+      "foreground": "#858aa0",
+      "fontStyle": "italic"
+    },
+    "razorTransition": {
+      "foreground": "#81c2ba",
+      "fontStyle": ""
+    },
     "razorDirective": {
-      "foreground": "#99a1f0",
+      "foreground": "#81c2ba",
       "fontStyle": "italic"
     },
     "razorDirectiveAttribute": {
-      "foreground": "#99a1f0",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "razorComponentElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorComponentAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "razorTagHelperElement": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": ""
     },
     "razorTagHelperAttribute": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": ""
     },
     "markdownHeading": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "bold"
     },
     "xmlDocCommentName": {
-      "foreground": "#b5a4dd",
+      "foreground": "#b3acdd",
       "fontStyle": "italic"
     },
     "xmlDocCommentText": {
@@ -2093,15 +2117,15 @@
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeName": {
-      "foreground": "#d39fbd",
+      "foreground": "#d8afcc",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeValue": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     },
     "xmlDocCommentAttributeQuotes": {
-      "foreground": "#a4dbba",
+      "foreground": "#addaa8",
       "fontStyle": "italic"
     }
   }


### PR DESCRIPTION
…s and improved the syntax to display the accents more

- Refactor razor syntax highlighting to improve readability and consistency.
- Improve markdown syntax highlighting.
- Improve JSON Key highlighting.
- Improve html attribute name highlighting.
- Improve css property value highlighting.
- Improve semantic token colors.
- Improve debug token expression colors.
- Improve symbol icon colors.
- Improve property readonly style.
- Removed entity name scope from support to prevent unexpected colorization.