### PR TITLE
feat(themes): updated the CHANGELOG and bumped theme version to 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.2.7] - 2025-05-01
+
+- Changed many scopes to represent the palette accents better with a less or more intense color
+  - classes -> `peach`
+  - interfaces/traits -> `yellow`
+  - enums -> `maroon`
+  - structs -> `red`
+  - functions/methods -> `blue`
+  - parameters -> `sapphire`
+  - fields/attributes -> `pink`
+  - properties -> `mauve`
+  - constants -> `lavender` (but far more intense)
+  - strings -> `green`
+  - text -> `sky`
+- Improved highlighting for razor files (directives, transitions, attributes and comments)
+- Changed JSON highlighting
+
 ## [1.2.6] - 2025-04-30
 
 - Fixed numerous highlighting issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
CHANGELOG update:
- Changed many scopes to represent the palette accents better with a less or more intense color
  - classes -> `peach`
  - interfaces/traits -> `yellow`
  - enums -> `maroon`
  - structs -> `red`
  - functions/methods -> `blue`
  - parameters -> `sapphire`
  - fields/attributes -> `pink`
  - properties -> `mauve`
  - constants -> `lavender` (but far more intense)
  - strings -> `green`
  - text -> `sky`
- Improved highlighting for razor files (directives, transitions, attributes and comments)
- Changed JSON highlighting