### PR TITLE
feat(themes): improve syntax highlighting for various languages and e…

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#eb8da8",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e69fab",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e6d6ad",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#e6b3d6",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#d35950",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#a55e23",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#af904d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#b980a0",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e78ea7",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#e09ea9",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e0d2aa",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#dfb1d1",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#e48da6",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#da9ba6",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#e7d3a6",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#d8afcc",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
@@ -804,6 +804,7 @@
         "variable.other.class",
         "entity.name.type",
         "entity.name.type.class",
+        "entity.name.class",
         "support.class"
       ],
       "settings": {
@@ -813,7 +814,7 @@
     },
     {
       "name": "struct",
-      "scope": ["variable.other.struct", "entity.name.type.struct"],
+      "scope": ["variable.other.struct", "entity.name.type.struct", "entity.name.struct"],
       "settings": {
         "foreground": "#dd8ba2",
         "fontStyle": ""
@@ -821,7 +822,7 @@
     },
     {
       "name": "enum",
-      "scope": ["variable.other.enum", "entity.name.type.enum"],
+      "scope": ["variable.other.enum", "entity.name.type.enum", "entity.name.enum"],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": ""
@@ -829,7 +830,13 @@
     },
     {
       "name": "enum member",
-      "scope": ["variable.other.enummember", "entity.name.type.enummember", "entity.name.variable.enum-member"],
+      "scope": [
+        "variable.other.enummember",
+        "entity.name.type.enummember",
+        "entity.name.variable.enum-member",
+        "entity.name.enumMember",
+        "entity.name.enummember"
+      ],
       "settings": {
         "foreground": "#cf959f",
         "fontStyle": "italic"
@@ -837,7 +844,7 @@
     },
     {
       "name": "interface",
-      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait"],
+      "scope": ["variable.other.interface", "entity.name.type.interface", "entity.name.type.trait", "entity.name.interface"],
       "settings": {
         "foreground": "#d6c59d",
         "fontStyle": ""
@@ -985,6 +992,9 @@
         "source.elm storage.type",
         "keyword.other.directive",
         "keyword.local",
+        "keyword.keys",
+        "keyword.control.ahk2",
+        "keyword.control.directive",
         "keyword.control.lua",
         "keyword.control.java",
         "keyword.control.flow",
@@ -1233,6 +1243,7 @@
         "keyword.operator.null-conditional",
         "keyword.operator.nullable-type",
         "punctuation.accessor",
+        "punctuation.definition.colon",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1270,6 +1281,7 @@
         "punctuation.definition.typeparameters",
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
+        "punctuation.definition.directive",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1411,7 +1423,8 @@
       "scope": [
         "entity.other.attribute-name",
         "entity.other.attribute-name.pseudo-class",
-        "meta.attribute.id entity.other.attribute-name"
+        "meta.attribute.id entity.other.attribute-name",
+        "entity.other.attribute"
       ],
       "settings": {
         "foreground": "#cca6c1",


### PR DESCRIPTION
…ntities

This commit enhances the syntax highlighting in the Calmppuccin themes by:

- Adding scope selectors for `entity.name.class`, `entity.name.struct`, `entity.name.enum`, `entity.name.enumMember`, and `entity.name.interface` to improve identification of these entities.
- Adding scope selectors for keywords in AHK2, Lua, and Java, as well as directives and keys to better highlight language-specific keywords.
- Adding scope selectors for punctuation such as colons and directives.
- Adding scope selectors for attributes.

These changes provide a more consistent and accurate syntax highlighting experience across different languages and code structures.