### PR TITLE
feat(themes): enhance syntax highlighting for namespaces, classes, ty…

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8dddd1",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#ecb38f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b5ade4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#3fa091",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#be7c3f",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#8f4fe4",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#8bd5ca",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e7b291",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b4ade0",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#81c2ba",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#e0af90",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#b3acdd",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
@@ -783,7 +783,12 @@
     },
     {
       "name": "namespace",
-      "scope": ["entity.name.namespace", "entity.name.type.namespace"],
+      "scope": [
+        "entity.name.namespace",
+        "entity.name.type.namespace",
+        "support.other.namespace",
+        "punctuation.separator.namespace.access"
+      ],
       "settings": {
         "foreground": "#7cb9b2",
         "fontStyle": ""
@@ -805,7 +810,9 @@
         "entity.name.type",
         "entity.name.type.class",
         "entity.name.class",
-        "support.class"
+        "support.class",
+        "support.class.builtin",
+        "entity.other.inherited-class"
       ],
       "settings": {
         "foreground": "#d8aa8d",
@@ -924,7 +931,6 @@
         "keyword.control punctuation.definition.function",
         "source.ocaml variable.interpolation string",
         "source.reason variable.interpolation",
-        "punctuation.definition.directive",
         "keyword.other.class.fileds",
         "source.toml entity.other.attribute-name",
         "source.css entity.name.tag.custom",
@@ -950,6 +956,7 @@
         "storage.type.interface",
         "storage.type.struct",
         "storage.type.enum",
+        "storage.type.numeric",
         "keyword.type",
         "keyword.type.primitive",
         "keyword.type.string",
@@ -973,6 +980,11 @@
         "keyword.other.rust",
         "keyword.other.static",
         "keyword.other.using",
+        "keyword.other.use",
+        "keyword.other.new",
+        "keyword.other.namespace",
+        "keyword.other.type",
+        "keyword.other.typedef",
         "variable.language",
         "keyword.operator.expression",
         "keyword.type.char",
@@ -996,12 +1008,15 @@
         "keyword.control.ahk2",
         "keyword.control.directive",
         "keyword.control.lua",
+        "keyword.control.c",
+        "keyword.control.cpp",
         "keyword.control.java",
         "keyword.control.flow",
         "keyword.control.loop",
         "keyword.control.conditional",
         "keyword.control.fun",
         "keyword.control.class",
+        "keyword.control.declare",
         "keyword.control.def",
         "keyword.control.import",
         "keyword.control.export",
@@ -1019,8 +1034,10 @@
         "keyword.control.throw",
         "keyword.control.else",
         "keyword.control.if",
+        "keyword.control.elseif",
         "keyword.control.do",
         "keyword.control.while",
+        "keyword.control.goto",
         "keyword.control.for",
         "keyword.control.foreach",
         "keyword.control.switch",
@@ -1031,8 +1048,8 @@
         "keyword.control.context",
         "support.type.sys-types",
         "support.type",
-        "support.other.namespace",
-        "support.other.namespace.use"
+        "support.other.namespace.use",
+        "meta.use"
       ],
       "settings": {
         "foreground": "#ada7d3",
@@ -1244,6 +1261,7 @@
         "keyword.operator.nullable-type",
         "punctuation.accessor",
         "punctuation.definition.colon",
+        "punctuation.separator.scope-resolution",
         "keyword.operator.ternary"
       ],
       "settings": {
@@ -1282,6 +1300,8 @@
         "comment.block.documentation.phpdoc.php keyword.other.type.php",
         "punctuation.definition.storage.type.objc",
         "punctuation.definition.directive",
+        "punctuation.section.embedded",
+        "punctuation.separator.inheritance",
         "markup punctuation.definition",
         "comment.block.documentation entity.name.type",
         "source.groovy storage.type",
@@ -1297,7 +1317,6 @@
         "source.reason support.type string",
         "support.class.crystal",
         "storage.type.integral",
-        "support.class.builtin",
         "source.tf meta.keyword.string",
         "source.tf meta.keyword.number",
         "source.scala entity.name.class",
@@ -1313,7 +1332,6 @@
       "name": "support",
       "scope": [
         "entity.other",
-        "meta.use.php",
         "punctuation.definition.parameters",
         "support.function.construct",
         "markup.changed.git_gutter",


### PR DESCRIPTION
…pes, and keywords

This commit improves the syntax highlighting in the Calmppuccin themes by:

- Expanding the scope of the `namespace` token to include `support.other.namespace` and `punctuation.separator.namespace.access` for better identification of namespace-related code.
- Adding `support.class.builtin` and `entity.other.inherited-class` to the `class` token scope, improving the highlighting of built-in and inherited classes.
- Adding `storage.type.numeric` to the `type` token scope.
- Adding several keywords such as `use`, `new`, `namespace`, `type`, and `typedef` to the `keyword` token scope for improved keyword highlighting.
- Adding several control keywords for C, C++, php, python, etc.
- Removing `punctuation.definition.directive` from the `string` token scope and adding it to the `punctuation` token scope.
- Adding `punctuation.separator.scope-resolution` to the `punctuation` token scope.
- Adding `punctuation.section.embedded` and `punctuation.separator.inheritance` to the `punctuation` token scope.
- Removing `meta.use.php` from the `support` token scope and adding `meta.use` to the `keyword` token scope.

These changes provide a more consistent and accurate syntax highlighting experience across different languages and code structures.