### PR TITLE
feat: bump version to 1.3.1 and updated the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.1] - 2025-05-05
+
+- Delegates are now displayed in italic style and use the `Flamingo` accent color
+
 ## [1.3.0] - 2025-05-04
 
 - Expanding the scope of the namespace token to include `support.other.namespace` and `punctuation.separator.namespace.access` for better identification of namespace-related code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This commit updates the version of the Calmppuccin VS Code theme to 1.3.1.

- Updates the version in `package.json` and `package-lock.json`.
- Adds a new entry to `CHANGELOG.md` describing the delegate token style changes.