### PR TITLE
feat: fix scope for `support.variable` and bump version to 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.3] - 2025-05-06
+
+- Fixed scope for `support.variable`
+
 ## [1.3.2] - 2025-05-06
 
 - Delegates and type parameters are not itlaic anymore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This commit addresses an issue with the scope of `support.variable` and updates the package version to 1.3.3.

- Fixed scope for `support.variable` to ensure correct highlighting.
- Updated version to 1.3.3 in `package.json`, `package-lock.json`, and `CHANGELOG.md`.