### PR TITLE
feat: release v1.3.5 with theme improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.5] - 2025-05-13
+
+- Resolved an issue where the interfaces in the `Mocha` and `Nitro Cold Brew` themes appeared excessively bright
+- Fixed frappe theme's escape character color
+
 ## [1.3.4] - 2025-05-10
 
 - Major improvements to the latte themes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.4.3",
+      "version": "1.3.5",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This commit releases version 1.3.5 of the Calmppuccin theme, which includes the following changes:

- Resolved an issue where the interfaces in the `Mocha` and `Nitro Cold Brew` themes appeared excessively bright.
- Fixed the escape character color in Frappe themes.
- Updated package version to 1.3.5.