### PR TITLE
feat: add log syntax highlighting to themes and adjust debug colors i…

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#8caaee",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#8caaee",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#8caaee",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#8caaee",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#8caaee",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#8caaee",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#8caaee1c",
     "minimapSlider.hoverBackground": "#8caaee2f",
     "minimapSlider.activeBackground": "#8caaee48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#8caaee",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#8caaee",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#8ca9eea6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#8caaee",
     "progressBar.background": "#8caaee",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#8caaee",
     "statusBarItem.prominentHoverBackground": "#8caaee",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#8caaee",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#8caaeea9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#8caaee",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#8caaee",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#8caaee",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#8caaee",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#eebebe",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#eebebe",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#eebebe",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#eebebe",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#eebebe",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#eebebe",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#eebebe1c",
     "minimapSlider.hoverBackground": "#eebebe2f",
     "minimapSlider.activeBackground": "#eebebe48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#eebebe",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#eebebe",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#eebebea6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#eebebe",
     "progressBar.background": "#eebebe",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#eebebe",
     "statusBarItem.prominentHoverBackground": "#eebebe",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#eebebe",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#eebebea9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#eebebe",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#eebebe",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#eebebe",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#eebebe",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#a6d189",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#a6d189",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#a6d189",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#a6d189",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#a6d189",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#a6d189",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#a6d1891c",
     "minimapSlider.hoverBackground": "#a6d1892f",
     "minimapSlider.activeBackground": "#a6d18948",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#a6d189",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#a6d189",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#a6d189a6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#a6d189",
     "progressBar.background": "#a6d189",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#a6d189",
     "statusBarItem.prominentHoverBackground": "#a6d189",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#a6d189",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#a6d189a9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#a6d189",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#a6d189",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#a6d189",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#a6d189",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#babbf1",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#babbf1",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#babbf1",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#babbf1",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#babbf1",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#babbf1",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#babbf11c",
     "minimapSlider.hoverBackground": "#babbf12f",
     "minimapSlider.activeBackground": "#babbf148",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#babbf1",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#babbf1",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#babbf1a6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#babbf1",
     "progressBar.background": "#babbf1",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#babbf1",
     "statusBarItem.prominentHoverBackground": "#babbf1",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#babbf1",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#babbf1a9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#babbf1",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#babbf1",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#babbf1",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#babbf1",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#ea999c",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#ea999c",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#ea999c",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#ea999c",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#ea999c",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#ea999c",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#ea999c1c",
     "minimapSlider.hoverBackground": "#ea999c2f",
     "minimapSlider.activeBackground": "#ea999c48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#ea999c",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#ea999c",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#ea999ca6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#ea999c",
     "progressBar.background": "#ea999c",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#ea999c",
     "statusBarItem.prominentHoverBackground": "#ea999c",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#ea999c",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#ea999ca9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#ea999c",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#ea999c",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#ea999c",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#ea999c",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#ca9ee6",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#ca9ee6",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#ca9ee6",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#ca9ee6",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#ca9ee6",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#ca9ee6",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#ca9ee61c",
     "minimapSlider.hoverBackground": "#ca9ee62f",
     "minimapSlider.activeBackground": "#ca9ee648",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#ca9ee6",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#ca9ee6",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#ca9ee6a6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#ca9ee6",
     "progressBar.background": "#ca9ee6",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#ca9ee6",
     "statusBarItem.prominentHoverBackground": "#ca9ee6",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#ca9ee6",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#ca9ee6a9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#ca9ee6",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#ca9ee6",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#ca9ee6",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#ca9ee6",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#ef9f76",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#ef9f76",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#ef9f76",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#ef9f76",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#ef9f76",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#ef9f76",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#ef9f761c",
     "minimapSlider.hoverBackground": "#ef9f762f",
     "minimapSlider.activeBackground": "#ef9f7648",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#ef9f76",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#ef9f76",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#ef9f76a6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#ef9f76",
     "progressBar.background": "#ef9f76",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#ef9f76",
     "statusBarItem.prominentHoverBackground": "#ef9f76",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#ef9f76",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#ef9f76a9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#ef9f76",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#ef9f76",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#ef9f76",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#ef9f76",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#f4b8e4",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#f4b8e4",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#f4b8e4",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#f4b8e4",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#f4b8e4",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#f4b8e4",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#f4b8e41c",
     "minimapSlider.hoverBackground": "#f4b8e42f",
     "minimapSlider.activeBackground": "#f4b8e448",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#f4b8e4",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#f4b8e4",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#f4b8e4a6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#f4b8e4",
     "progressBar.background": "#f4b8e4",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#f4b8e4",
     "statusBarItem.prominentHoverBackground": "#f4b8e4",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#f4b8e4",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#f4b8e4a9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#f4b8e4",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#f4b8e4",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#f4b8e4",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#f4b8e4",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#e78284",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e78284",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#e78284",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e78284",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#e78284",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e78284",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#e782841c",
     "minimapSlider.hoverBackground": "#e782842f",
     "minimapSlider.activeBackground": "#e7828448",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e78284",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#e78284",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#e78284a6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e78284",
     "progressBar.background": "#e78284",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e78284",
     "statusBarItem.prominentHoverBackground": "#e78284",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#e78284",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e78284a9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#e78284",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e78284",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e78284",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e78284",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#f2d5cf",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#f2d5cf",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#f2d5cf",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#f2d5cf",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#f2d5cf",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#f2d5cf",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#f2d5cf1c",
     "minimapSlider.hoverBackground": "#f2d5cf2f",
     "minimapSlider.activeBackground": "#f2d5cf48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#f2d5cf",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#f2d5cf",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#f2d5cfa6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#f2d5cf",
     "progressBar.background": "#f2d5cf",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#f2d5cf",
     "statusBarItem.prominentHoverBackground": "#f2d5cf",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#f2d5cf",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#f2d5cfa9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#f2d5cf",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#f2d5cf",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#f2d5cf",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#f2d5cf",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#85c1dc",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#85c1dc",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#85c1dc",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#85c1dc",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#85c1dc",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#85c1dc",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#85c1dc1c",
     "minimapSlider.hoverBackground": "#85c1dc2f",
     "minimapSlider.activeBackground": "#85c1dc48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#85c1dc",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#85c1dc",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#85c1dca6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#85c1dc",
     "progressBar.background": "#85c1dc",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#85c1dc",
     "statusBarItem.prominentHoverBackground": "#85c1dc",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#85c1dc",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#85c1dca9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#85c1dc",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#85c1dc",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#85c1dc",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#85c1dc",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#99d1db",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#99d1db",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#99d1db",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#99d1db",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#99d1db",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#99d1db",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#99d1db1c",
     "minimapSlider.hoverBackground": "#99d1db2f",
     "minimapSlider.activeBackground": "#99d1db48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#99d1db",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#99d1db",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#99d1dba6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#99d1db",
     "progressBar.background": "#99d1db",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#99d1db",
     "statusBarItem.prominentHoverBackground": "#99d1db",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#99d1db",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#99d1dba9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#99d1db",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#99d1db",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#99d1db",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#99d1db",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#81c8be",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#81c8be",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#81c8be",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#81c8be",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#81c8be",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#81c8be",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#81c8be1c",
     "minimapSlider.hoverBackground": "#81c8be2f",
     "minimapSlider.activeBackground": "#81c8be48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#81c8be",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#81c8be",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#81c8bea6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#81c8be",
     "progressBar.background": "#81c8be",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#81c8be",
     "statusBarItem.prominentHoverBackground": "#81c8be",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#81c8be",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#81c8bea9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#81c8be",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#81c8be",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#81c8be",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#81c8be",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c6d0f5",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#dd7d9a",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b9b0e9",
     "debugTokenExpression.boolean": "#a097f8",
     "debugTokenExpression.string": "#ade6a7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#dd7d9a",
+    "debugIcon.breakpointForeground": "#dd7d9a",
+    "debugIcon.breakpointDisabledForeground": "#dd7d9a99",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#dd7d9a",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#89d3ca",
     "debugIcon.stepOverForeground": "#e5c890",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#dd7d9a",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c6d0f5",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#dd7d9a33",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#dd7d9a26",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#dd7d9acc",
 
     "descriptionForeground": "#c6d0f5",
     "disabledForeground": "#c6d0f54d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#dd7d9a",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c6d0f570",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#2f3344",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#dd7d9a",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e5c890",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#79a0df",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#222532",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#dd7d9a",
+    "editorMarkerNavigationInfo.background": "#79a0df",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#2f3344",
     "editorOverviewRuler.border": "#585b706c",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#dd7d9a",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#dd7d9a",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c6d0f5",
 
     "gitDecoration.conflictingResourceForeground": "#e5c890",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#dd7d9a",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#dd7d9a",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#79a0df",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e5c890",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c6d0f5",
     "inputOption.activeBorder": "#e5c890",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#dd7d9a",
     "inputValidation.errorBorder": "#22253233",
     "inputValidation.errorForeground": "#222532",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#79a0df",
     "inputValidation.infoBorder": "#22253233",
     "inputValidation.infoForeground": "#222532",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e5c890",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#dd7d9a",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#222532",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#79a0df33",
+    "merge.incomingHeaderBackground": "#79a0df66",
 
     "minimap.background": "#2f33449d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#dd7d9abf",
     "minimapSlider.background": "#e5c8901c",
     "minimapSlider.hoverBackground": "#e5c8902f",
     "minimapSlider.activeBackground": "#e5c89048",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#dd7d9abf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e5c890",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c6d0f5",
     "notifications.background": "#2f3344",
     "notifications.border": "#e5c890",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#79a0df",
+    "notificationsErrorIcon.foreground": "#dd7d9a",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#79a0df",
 
     "panel.background": "#282b3a",
     "panel.border": "#e5c890a6",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e5c890",
     "progressBar.background": "#e5c890",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#dd7d9a",
+    "problemsInfoIcon.foreground": "#79a0df",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e5c890",
     "statusBarItem.prominentHoverBackground": "#e5c890",
     "statusBarItem.prominentHoverForeground": "#222532",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#dd7d9a",
     "statusBarItem.errorBackground": "#222532",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#222532",
@@ -546,10 +546,10 @@
     "terminal.background": "#2f3344",
     "terminal.foreground": "#c6d0f5",
     "terminal.ansiBlack": "#51576d",
-    "terminal.ansiRed": "#e78284",
+    "terminal.ansiRed": "#dd7d9a",
     "terminal.ansiGreen": "#a6d189",
     "terminal.ansiYellow": "#e5c890",
-    "terminal.ansiBlue": "#e5c890",
+    "terminal.ansiBlue": "#79a0df",
     "terminal.ansiMagenta": "#f4b8e4",
     "terminal.ansiCyan": "#89d3ca",
     "terminal.ansiWhite": "#a5adce",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e5c890a9",
     "terminalCommandDecoration.defaultBackground": "#9ea1b4",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#dd7d9a",
 
     "testing.runAction": "#e5c890",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#dd7d9a",
+    "testing.iconFailed": "#dd7d9a",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c6d0f5",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#dd7d9a",
+    "testing.iconFailed.retired": "#dd7d9a",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c6d0f5",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e5c890",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#dd7d9a26",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e5c890",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#dd7d9a33",
+    "testing.uncoveredBackground": "#dd7d9a33",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#dd7d9a40",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e5c890",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a2e7c7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bcc7e6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#79a0df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0dbe9",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c7a2f3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#ade6a7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#dd7d9a",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8046cc",
     "debugTokenExpression.boolean": "#463bdf",
     "debugTokenExpression.string": "#459163",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#398f82",
     "debugIcon.stepOverForeground": "#1c5ee4",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#1c5ee4",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#1c5ee4",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#1c5ee4",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#1c5ee4",
 
@@ -612,7 +612,7 @@
     "textBlockQuote.border": "#cfd1d4",
     "textCodeBlock.background": "#cfd1d4",
     "textLink.activeForeground": "#7ac3cf",
-    "textLink.foreground": "#87aae2",
+    "textLink.foreground": "#5282cf",
     "textPreformat.foreground": "#474a63",
     "textSeparator.foreground": "#1c5ee4",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#c46a6a",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#c46a6a",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#c46a6a",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#c46a6a",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#c46a6a",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#398f26",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#398f26",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#398f26",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#398f26",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#398f26",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#6678e0",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#6678e0",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#6678e0",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#6678e0",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#6678e0",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#d1404c",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#d1404c",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#d1404c",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#d1404c",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#d1404c",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#7b34da",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#7b34da",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#7b34da",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#7b34da",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#7b34da",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#dd570a",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#dd570a",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#dd570a",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#dd570a",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#dd570a",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#d169b5",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#d169b5",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#d169b5",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#d169b5",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#d169b5",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#c70e36",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#c70e36",
 
     "testing.runAction": "#c70e36",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#c70e36",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#c70e36",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#c70e36",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#c97e6d",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#c97e6d",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#c97e6d",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#c97e6d",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#c97e6d",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#1c8da1",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#1c8da1",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#1c8da1",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#1c8da1",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#1c8da1",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#0396cf",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#0396cf",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#0396cf",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#0396cf",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#0396cf",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#148186",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#148186",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#148186",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#148186",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#148186",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -77,26 +77,26 @@
     "debugTokenExpression.type": "#8f4fe4",
     "debugTokenExpression.boolean": "#4a5af0",
     "debugTokenExpression.string": "#4a996a",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
-    "debugIcon.startForeground": "#95ce8f",
-    "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#5282cf",
+    "debugIcon.stopForeground": "#d20f39",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#3fa091",
     "debugIcon.stepOverForeground": "#b88b12",
     "debugIcon.stepIntoForeground": "#474a63",
     "debugIcon.stepOutForeground": "#474a63",
-    "debugIcon.continueForeground": "#95ce8f",
+    "debugIcon.continueForeground": "#40a02b",
     "debugIcon.stepBackForeground": "#585b70",
-    "debugConsole.infoForeground": "#87aae2",
-    "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
-    "debugConsole.sourceForeground": "#c9b4b0",
+    "debugConsole.infoForeground": "#5282cf",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#c58a7e",
     "debugConsoleInputIcon.foreground": "#474a63",
 
     "diffEditor.border": "#5e617e",
@@ -579,32 +579,32 @@
     "terminalCommandDecoration.errorBackground": "#d20f39",
 
     "testing.runAction": "#b88b12",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
-    "testing.iconPassed": "#95ce8f",
-    "testing.iconQueued": "#87aae2",
+    "testing.iconErrored": "#d20f39",
+    "testing.iconFailed": "#d20f39",
+    "testing.iconPassed": "#40a02b",
+    "testing.iconQueued": "#5282cf",
     "testing.iconUnset": "#474a63",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
-    "testing.iconPassed.retired": "#95ce8f",
-    "testing.iconQueued.retired": "#87aae2",
+    "testing.iconErrored.retired": "#d20f39",
+    "testing.iconFailed.retired": "#d20f39",
+    "testing.iconPassed.retired": "#40a02b",
+    "testing.iconQueued.retired": "#5282cf",
     "testing.iconUnset.retired": "#474a63",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#b88b12",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
-    "testing.message.info.decorationForeground": "#95ce8fcc",
-    "testing.message.info.lineBackground": "#95ce8f26",
+    "testing.message.error.lineBackground": "#d20f3926",
+    "testing.message.info.decorationForeground": "#40a02bcc",
+    "testing.message.info.lineBackground": "#40a02b26",
     "testing.messagePeekBorder": "#b88b12",
     "testing.messagePeekHeaderBackground": "#585b70",
-    "testing.coveredBackground": "#95ce8f4d",
+    "testing.coveredBackground": "#40a02b4d",
     "testing.coveredBorder": "#00000000",
-    "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.coveredGutterBackground": "#40a02b4d",
+    "testing.uncoveredBranchBackground": "#d20f3933",
+    "testing.uncoveredBackground": "#d20f3933",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d20f3940",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#b88b12",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8de652",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#474a63",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#1c5ee4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#2ba3d3",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#9a3ba5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#459163",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d20f39",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#83a5e7",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#232638",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#83a5e7",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#232638",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#83a5e7",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#83a5e7",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#83a5e7",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#83a5e7",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#2326389d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#83a5e71c",
     "minimapSlider.hoverBackground": "#83a5e72f",
     "minimapSlider.activeBackground": "#83a5e748",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#83a5e7",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#232638",
     "notifications.border": "#83a5e7",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1d1f2f",
     "panel.border": "#83a4e793",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#83a5e7",
     "progressBar.background": "#83a5e7",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#83a5e7",
     "statusBarItem.prominentHoverBackground": "#83a5e7",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#232638",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#83a5e7",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#83a5e7a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#83a5e7",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#83a5e7",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#83a5e7",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#83a5e7",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#e4bcbc",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e4bcbc",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#e4bcbc",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e4bcbc",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#e4bcbc",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e4bcbc",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#e4bcbc1c",
     "minimapSlider.hoverBackground": "#e4bcbc2f",
     "minimapSlider.activeBackground": "#e4bcbc48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e4bcbc",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#e4bcbc",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#e4bcbc93",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e4bcbc",
     "progressBar.background": "#e4bcbc",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e4bcbc",
     "statusBarItem.prominentHoverBackground": "#e4bcbc",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e4bcbca9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#e4bcbc",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e4bcbc",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e4bcbc",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e4bcbc",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#9fcf8f",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#9fcf8f",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#9fcf8f",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#9fcf8f",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#9fcf8f",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#9fcf8f",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#9fcf8f1c",
     "minimapSlider.hoverBackground": "#9fcf8f2f",
     "minimapSlider.activeBackground": "#9fcf8f48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#9fcf8f",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#9fcf8f",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#9fcf8f93",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#9fcf8f",
     "progressBar.background": "#9fcf8f",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#9fcf8f",
     "statusBarItem.prominentHoverBackground": "#9fcf8f",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#9fcf8f",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#9fcf8fa9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#9fcf8f",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#9fcf8f",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#9fcf8f",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#9fcf8f",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#acb2e9",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#acb2e9",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#acb2e9",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#acb2e9",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#acb2e9",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#acb2e9",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#acb2e91c",
     "minimapSlider.hoverBackground": "#acb2e92f",
     "minimapSlider.activeBackground": "#acb2e948",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#acb2e9",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#acb2e9",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#acb2e993",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#acb2e9",
     "progressBar.background": "#acb2e9",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#acb2e9",
     "statusBarItem.prominentHoverBackground": "#acb2e9",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#acb2e9a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#acb2e9",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#acb2e9",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#acb2e9",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#acb2e9",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#e49399",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e49399",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#e49399",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e49399",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#e49399",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e49399",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#e493991c",
     "minimapSlider.hoverBackground": "#e493992f",
     "minimapSlider.activeBackground": "#e4939948",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e49399",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#e49399",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#e4939993",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e49399",
     "progressBar.background": "#e49399",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e49399",
     "statusBarItem.prominentHoverBackground": "#e49399",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e49399a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#e49399",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e49399",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e49399",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e49399",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#bb97e7",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#bb97e7",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#bb97e7",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#bb97e7",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#bb97e7",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#bb97e7",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#bb97e71c",
     "minimapSlider.hoverBackground": "#bb97e72f",
     "minimapSlider.activeBackground": "#bb97e748",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#bb97e7",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#bb97e7",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#bb97e793",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#bb97e7",
     "progressBar.background": "#bb97e7",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#bb97e7",
     "statusBarItem.prominentHoverBackground": "#bb97e7",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#bb97e7a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#bb97e7",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#bb97e7",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#bb97e7",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#bb97e7",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#e69e78",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e69e78",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#e69e78",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e69e78",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#e69e78",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e69e78",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#e69e781c",
     "minimapSlider.hoverBackground": "#e69e782f",
     "minimapSlider.activeBackground": "#e69e7848",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e69e78",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#e69e78",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#e69e7893",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e69e78",
     "progressBar.background": "#e69e78",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e69e78",
     "statusBarItem.prominentHoverBackground": "#e69e78",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e69e78a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#e69e78",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e69e78",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e69e78",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e69e78",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#e6b1d7",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e6b1d7",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#e6b1d7",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e6b1d7",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#e6b1d7",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e6b1d7",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#e6b1d71c",
     "minimapSlider.hoverBackground": "#e6b1d72f",
     "minimapSlider.activeBackground": "#e6b1d748",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e6b1d7",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#e6b1d7",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#e6b1d793",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e6b1d7",
     "progressBar.background": "#e6b1d7",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e6b1d7",
     "statusBarItem.prominentHoverBackground": "#e6b1d7",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#e6b1d7",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e6b1d7a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#e6b1d7",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e6b1d7",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e6b1d7",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e6b1d7",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#e0808e",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e0808e",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#e0808e",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e0808e",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#e0808e",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e0808e",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#e0808e1c",
     "minimapSlider.hoverBackground": "#e0808e2f",
     "minimapSlider.activeBackground": "#e0808e48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e0808e",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#e0808e",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#e0808e93",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e0808e",
     "progressBar.background": "#e0808e",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e0808e",
     "statusBarItem.prominentHoverBackground": "#e0808e",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -549,7 +549,7 @@
     "terminal.ansiRed": "#e0808e",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e0808ea9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#e0808e",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e0808e",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e0808e",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e0808e",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#e7d0cb",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e7d0cb",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#e7d0cb",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e7d0cb",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#e7d0cb",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e7d0cb",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#e7d0cb1c",
     "minimapSlider.hoverBackground": "#e7d0cb2f",
     "minimapSlider.activeBackground": "#e7d0cb48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e7d0cb",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#e7d0cb",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#e7d0cb93",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e7d0cb",
     "progressBar.background": "#e7d0cb",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e7d0cb",
     "statusBarItem.prominentHoverBackground": "#e7d0cb",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e7d0cba9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#e7d0cb",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e7d0cb",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e7d0cb",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e7d0cb",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#79bbda",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#79bbda",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#79bbda",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#79bbda",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#79bbda",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#79bbda",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#79bbda1c",
     "minimapSlider.hoverBackground": "#79bbda2f",
     "minimapSlider.activeBackground": "#79bbda48",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#79bbda",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#79bbda",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#79bbda93",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#79bbda",
     "progressBar.background": "#79bbda",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#79bbda",
     "statusBarItem.prominentHoverBackground": "#79bbda",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#79bbdaa9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#79bbda",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#79bbda",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#79bbda",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#79bbda",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#89cbd6",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#89cbd6",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#89cbd6",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#89cbd6",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#89cbd6",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#89cbd6",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#89cbd61c",
     "minimapSlider.hoverBackground": "#89cbd62f",
     "minimapSlider.activeBackground": "#89cbd648",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#89cbd6",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#89cbd6",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#89cbd693",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#89cbd6",
     "progressBar.background": "#89cbd6",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#89cbd6",
     "statusBarItem.prominentHoverBackground": "#89cbd6",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#eed49f",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#89cbd6a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#89cbd6",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#89cbd6",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#89cbd6",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#89cbd6",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#85ccc1",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#85ccc1",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#85ccc1",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#85ccc1",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#85ccc1",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#85ccc1",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#85ccc11c",
     "minimapSlider.hoverBackground": "#85ccc12f",
     "minimapSlider.activeBackground": "#85ccc148",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#85ccc1",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#85ccc1",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#85ccc193",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#85ccc1",
     "progressBar.background": "#85ccc1",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#85ccc1",
     "statusBarItem.prominentHoverBackground": "#85ccc1",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#85ccc1",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#85ccc1a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#85ccc1",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#85ccc1",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#85ccc1",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#85ccc1",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -44,7 +44,7 @@
 
     "charts.foreground": "#c2cae9",
     "charts.lines": "#bac2de",
-    "charts.red": "#d47b95",
+    "charts.red": "#d87c97",
     "charts.blue": "#87a8dd",
     "charts.yellow": "#e6c889",
     "charts.orange": "#e4a47c",
@@ -77,15 +77,15 @@
     "debugTokenExpression.type": "#b8b0e4",
     "debugTokenExpression.boolean": "#9b92f1",
     "debugTokenExpression.string": "#addfa7",
-    "debugTokenExpression.error": "#d47b95",
-    "debugIcon.breakpointForeground": "#d47b95",
-    "debugIcon.breakpointDisabledForeground": "#d47b9599",
+    "debugTokenExpression.error": "#d87c97",
+    "debugIcon.breakpointForeground": "#d87c97",
+    "debugIcon.breakpointDisabledForeground": "#d87c9799",
     "debugIcon.breakpointUnverifiedForeground": "#a6738c",
     "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
     "debugIcon.breakpointStackframeForeground": "#585b70",
     "debugIcon.startForeground": "#95ce8f",
     "debugIcon.pauseForeground": "#87aae2",
-    "debugIcon.stopForeground": "#d47b95",
+    "debugIcon.stopForeground": "#d87c97",
     "debugIcon.disconnectForeground": "#585b70",
     "debugIcon.restartForeground": "#85cac2",
     "debugIcon.stepOverForeground": "#e0c896",
@@ -95,23 +95,23 @@
     "debugIcon.stepBackForeground": "#585b70",
     "debugConsole.infoForeground": "#87aae2",
     "debugConsole.warningForeground": "#e9b391",
-    "debugConsole.errorForeground": "#d47b95",
+    "debugConsole.errorForeground": "#d87c97",
     "debugConsole.sourceForeground": "#f5e0dc",
     "debugConsoleInputIcon.foreground": "#c2cae9",
 
     "diffEditor.border": "#585b70",
     "diffEditor.insertedTextBackground": "#95ce8f33",
-    "diffEditor.removedTextBackground": "#d47b9533",
+    "diffEditor.removedTextBackground": "#d87c9733",
     "diffEditor.insertedLineBackground": "#95ce8f26",
-    "diffEditor.removedLineBackground": "#d47b9526",
+    "diffEditor.removedLineBackground": "#d87c9726",
     "diffEditor.diagonalFill": "#585b7099",
     "diffEditorOverview.insertedForeground": "#95ce8fcc",
-    "diffEditorOverview.removedForeground": "#d47b95cc",
+    "diffEditorOverview.removedForeground": "#d87c97cc",
 
     "descriptionForeground": "#c2cae9",
     "disabledForeground": "#c2cae94d",
 
-    "errorForeground": "#d47b95",
+    "errorForeground": "#d87c97",
 
     "editorGhostText.border": "#00000000",
     "editorGhostText.foreground": "#c2cae970",
@@ -184,7 +184,7 @@
 
     "editorGutter.background": "#24273a",
     "editorGutter.addedBackground": "#95ce8f",
-    "editorGutter.deletedBackground": "#d47b95",
+    "editorGutter.deletedBackground": "#d87c97",
     "editorGutter.modifiedBackground": "#d6c08f",
     "editorGutter.commentRangeForeground": "#313244",
     "editorGutter.commentGlyphForeground": "#e0c896",
@@ -199,7 +199,7 @@
     "editorIndentGuide.activeBackground1": "#585b70",
     "editorIndentGuide.background1": "#45475a",
 
-    "editorInfo.foreground": "#789cd6",
+    "editorInfo.foreground": "#799fdb",
     "editorInfo.border": "#00000000",
     "editorInfo.background": "#00000000",
 
@@ -218,18 +218,18 @@
     "editorLightBulb.foreground": "#d6c08f",
 
     "editorMarkerNavigation.background": "#171825",
-    "editorMarkerNavigationError.background": "#d47b95",
-    "editorMarkerNavigationInfo.background": "#789cd6",
+    "editorMarkerNavigationError.background": "#d87c97",
+    "editorMarkerNavigationInfo.background": "#799fdb",
     "editorMarkerNavigationWarning.background": "#e2a47d",
 
     "editorOverviewRuler.background": "#24273a",
     "editorOverviewRuler.border": "#585b703f",
     "editorOverviewRuler.modifiedForeground": "#d6c08f",
     "editorOverviewRuler.addedForeground": "#95ce8f",
-    "editorOverviewRuler.deletedForeground": "#d47b95",
+    "editorOverviewRuler.deletedForeground": "#d87c97",
     "editorOverviewRuler.errorForeground": "#d85369",
     "editorOverviewRuler.commonContentForeground": "#d6c08f",
-    "editorOverviewRuler.currentContentForeground": "#d47b95",
+    "editorOverviewRuler.currentContentForeground": "#d87c97",
     "editorOverviewRuler.incomingContentForeground": "#95ce8f",
 
     "editorRuler.foreground": "#585b70",
@@ -284,12 +284,12 @@
     "foreground": "#c2cae9",
 
     "gitDecoration.conflictingResourceForeground": "#e0c896",
-    "gitDecoration.deletedResourceForeground": "#d47b95",
+    "gitDecoration.deletedResourceForeground": "#d87c97",
     "gitDecoration.ignoredResourceForeground": "#6c7086",
     "gitDecoration.modifiedResourceForeground": "#d6c08f",
-    "gitDecoration.stageDeletedResourceForeground": "#d47b95",
+    "gitDecoration.stageDeletedResourceForeground": "#d87c97",
     "gitDecoration.stageModifiedResourceForeground": "#d6c08f",
-    "gitDecoration.submoduleResourceForeground": "#789cd6",
+    "gitDecoration.submoduleResourceForeground": "#799fdb",
     "gitDecoration.untrackedResourceForeground": "#95ce8f",
 
     "icon.foreground": "#e0c896",
@@ -301,10 +301,10 @@
     "inputOption.activeBackground": "#585b70",
     "inputOption.activeForeground": "#c2cae9",
     "inputOption.activeBorder": "#e0c896",
-    "inputValidation.errorBackground": "#d47b95",
+    "inputValidation.errorBackground": "#d87c97",
     "inputValidation.errorBorder": "#17182533",
     "inputValidation.errorForeground": "#171825",
-    "inputValidation.infoBackground": "#789cd6",
+    "inputValidation.infoBackground": "#799fdb",
     "inputValidation.infoBorder": "#17182533",
     "inputValidation.infoForeground": "#171825",
     "inputValidation.warningBackground": "#e2a47d",
@@ -324,7 +324,7 @@
     "list.inactiveSelectionForeground": "#e0c896",
     "list.warningForeground": "#e2a47d",
     "listFilterWidget.background": "#45475a",
-    "listFilterWidget.noMatchesOutline": "#d47b95",
+    "listFilterWidget.noMatchesOutline": "#d87c97",
     "listFilterWidget.outline": "#00000000",
 
     "keybindingLabel.background": "#171825",
@@ -347,20 +347,20 @@
     "merge.commonHeaderBackground": "#585b7080",
     "merge.currentContentBackground": "#95ce8f33",
     "merge.currentHeaderBackground": "#95ce8f66",
-    "merge.incomingContentBackground": "#789cd633",
-    "merge.incomingHeaderBackground": "#789cd666",
+    "merge.incomingContentBackground": "#799fdb33",
+    "merge.incomingHeaderBackground": "#799fdb66",
 
     "minimap.background": "#24273a9d",
     "minimap.findMatchHighlight": "#7ac3cf4d",
     "minimap.selectionHighlight": "#585b70bf",
     "minimap.selectionOccurrenceHighlight": "#585b70bf",
     "minimap.warningHighlight": "#e2a47dbf",
-    "minimap.errorHighlight": "#d47b95bf",
+    "minimap.errorHighlight": "#d87c97bf",
     "minimapSlider.background": "#e0c8961c",
     "minimapSlider.hoverBackground": "#e0c8962f",
     "minimapSlider.activeBackground": "#e0c89648",
     "minimapGutter.addedBackground": "#95ce8fbf",
-    "minimapGutter.deletedBackground": "#d47b95bf",
+    "minimapGutter.deletedBackground": "#d87c97bf",
     "minimapGutter.modifiedBackground": "#d6c08fbf",
 
     "notificationCenter.border": "#e0c896",
@@ -370,10 +370,10 @@
     "notifications.foreground": "#c2cae9",
     "notifications.background": "#24273a",
     "notifications.border": "#e0c896",
-    "notificationLink.foreground": "#789cd6",
-    "notificationsErrorIcon.foreground": "#d47b95",
+    "notificationLink.foreground": "#799fdb",
+    "notificationsErrorIcon.foreground": "#d87c97",
     "notificationsWarningIcon.foreground": "#e2a47d",
-    "notificationsInfoIcon.foreground": "#789cd6",
+    "notificationsInfoIcon.foreground": "#799fdb",
 
     "panel.background": "#1e2030",
     "panel.border": "#e0c89693",
@@ -407,8 +407,8 @@
     "pickerGroup.foreground": "#e0c896",
     "progressBar.background": "#e0c896",
 
-    "problemsErrorIcon.foreground": "#d47b95",
-    "problemsInfoIcon.foreground": "#789cd6",
+    "problemsErrorIcon.foreground": "#d87c97",
+    "problemsInfoIcon.foreground": "#799fdb",
     "problemsWarningIcon.foreground": "#e2a47d",
 
     "profileBadge.background": "#9996aa",
@@ -477,7 +477,7 @@
     "statusBarItem.prominentForeground": "#e0c896",
     "statusBarItem.prominentHoverBackground": "#e0c896",
     "statusBarItem.prominentHoverForeground": "#171825",
-    "statusBarItem.errorForeground": "#d47b95",
+    "statusBarItem.errorForeground": "#d87c97",
     "statusBarItem.errorBackground": "#171825",
     "statusBarItem.warningForeground": "#e2a47d",
     "statusBarItem.warningBackground": "#171825",
@@ -546,10 +546,10 @@
     "terminal.background": "#24273a",
     "terminal.foreground": "#c2cae9",
     "terminal.ansiBlack": "#494d64",
-    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiRed": "#d87c97",
     "terminal.ansiGreen": "#a6da95",
     "terminal.ansiYellow": "#e0c896",
-    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBlue": "#799fdb",
     "terminal.ansiMagenta": "#f5bde6",
     "terminal.ansiCyan": "#85cac2",
     "terminal.ansiWhite": "#a5adcb",
@@ -576,24 +576,24 @@
     "terminal.findMatchHighlightBorder": "#e0c896a9",
     "terminalCommandDecoration.defaultBackground": "#8f92a3",
     "terminalCommandDecoration.successBackground": "#95ce8f",
-    "terminalCommandDecoration.errorBackground": "#d47b95",
+    "terminalCommandDecoration.errorBackground": "#d87c97",
 
     "testing.runAction": "#e0c896",
-    "testing.iconErrored": "#d47b95",
-    "testing.iconFailed": "#d47b95",
+    "testing.iconErrored": "#d87c97",
+    "testing.iconFailed": "#d87c97",
     "testing.iconPassed": "#95ce8f",
     "testing.iconQueued": "#87aae2",
     "testing.iconUnset": "#c2cae9",
     "testing.iconSkipped": "#a6adc8",
-    "testing.iconErrored.retired": "#d47b95",
-    "testing.iconFailed.retired": "#d47b95",
+    "testing.iconErrored.retired": "#d87c97",
+    "testing.iconFailed.retired": "#d87c97",
     "testing.iconPassed.retired": "#95ce8f",
     "testing.iconQueued.retired": "#87aae2",
     "testing.iconUnset.retired": "#c2cae9",
     "testing.iconSkipped.retired": "#a6adc8",
     "testing.peekBorder": "#e0c896",
     "testing.peekHeaderBackground": "#585b70",
-    "testing.message.error.lineBackground": "#d47b9526",
+    "testing.message.error.lineBackground": "#d87c9726",
     "testing.message.info.decorationForeground": "#95ce8fcc",
     "testing.message.info.lineBackground": "#95ce8f26",
     "testing.messagePeekBorder": "#e0c896",
@@ -601,10 +601,10 @@
     "testing.coveredBackground": "#95ce8f4d",
     "testing.coveredBorder": "#00000000",
     "testing.coveredGutterBackground": "#95ce8f4d",
-    "testing.uncoveredBranchBackground": "#d47b9533",
-    "testing.uncoveredBackground": "#d47b9533",
+    "testing.uncoveredBranchBackground": "#d87c9733",
+    "testing.uncoveredBackground": "#d87c9733",
     "testing.uncoveredBorder": "#00000000",
-    "testing.uncoveredGutterBackground": "#d47b9540",
+    "testing.uncoveredGutterBackground": "#d87c9740",
     "testing.coverCountBadgeBackground": "#00000000",
     "testing.coverCountBadgeForeground": "#e0c896",
 
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#a3e0c4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4e0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#799fdb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a0d6e2",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c19eec",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addfa7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d87c97",
         "fontStyle": ""
       }
     },

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#bbc4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#789cd6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#a1d4df",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#c3a0eb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#addaa8",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d47b95",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
@@ -1101,6 +1101,54 @@
       }
     },
     {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#b1b9d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#7698cf",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#98c7d1",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#bf9de6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#a8d1a4",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#d17a94",
+        "fontStyle": ""
+      }
+    },
+    {
       "name": "string",
       "scope": [
         "string",

--- a/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },

--- a/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
@@ -546,10 +546,10 @@
     "terminal.background": "#0b0b11",
     "terminal.foreground": "#8c92a7",
     "terminal.ansiBlack": "#333542",
-    "terminal.ansiRed": "#bb7187",
+    "terminal.ansiRed": "#bd7087",
     "terminal.ansiGreen": "#85b480",
     "terminal.ansiYellow": "#bba981",
-    "terminal.ansiBlue": "#6f8ebe",
+    "terminal.ansiBlue": "#708fc0",
     "terminal.ansiMagenta": "#ad8ba4",
     "terminal.ansiCyan": "#78afa9",
     "terminal.ansiWhite": "#959baf",
@@ -1097,6 +1097,54 @@
       "scope": ["variable.other.event"],
       "settings": {
         "foreground": "#8ebda7",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log date",
+      "scope": ["log.date"],
+      "settings": {
+        "foreground": "#a2a8bb",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log info",
+      "scope": ["log.info"],
+      "settings": {
+        "foreground": "#708fc0",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log text and constant",
+      "scope": ["text.log", "log.constant"],
+      "settings": {
+        "foreground": "#8db4bd",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log debug",
+      "scope": ["log.debug"],
+      "settings": {
+        "foreground": "#a78ac5",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log exceptiontype",
+      "scope": ["log.exceptiontype"],
+      "settings": {
+        "foreground": "#96b694",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "log error",
+      "scope": ["log.error"],
+      "settings": {
+        "foreground": "#bd7087",
         "fontStyle": ""
       }
     },


### PR DESCRIPTION
…n latte themes

This commit introduces syntax highlighting for log files across various Calmppuccin themes, enhancing readability and developer experience when working with logs.

The following changes were made:

- Added new color rules for `log.date`, `log.info`, `text.log`, `log.constant`, `log.debug`, `log.exceptiontype`, and `log.error` scopes.