### PR TITLE
feat: release v1.3.6 with log scopes and theme color improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.6] - 2025-05-16
+
+- Added scopes for log files
+- Improved info and error colors across all themes
+- Adjusted debug colors for latte themes
+
 ## [1.3.5] - 2025-05-13
 
 - Resolved an issue where the interfaces in the `Mocha` and `Nitro Cold Brew` themes appeared excessively bright

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This commit releases version 1.3.6 of the Calmppuccin theme, which includes the following changes:

- Added scopes for log files (`log.date`, `log.info`, `text.log`, `log.constant`, `log.debug`, `log.exceptiontype`, and `log.error`).
- Improved info and error colors across all themes.
- Adjusted debug colors for latte themes.
- Updated package version to 1.3.6.