### PR TITLE
feat: improve editorconfig and keyword highlighting, and add source. ignore scope to text

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
@@ -899,6 +899,7 @@
         "constant.string.documentation.powershell",
         "entity.name.lifetime.rust",
         "entity.name.section",
+        "entity.name.section.group-title.editorconfig",
         "entity.name.type.primitive",
         "entity.other.attribute-name.pseudo-element",
         "keyword.contro.rust",
@@ -1077,7 +1078,8 @@
         "variable.language.special.self.python",
         "variable.language.this",
         "variable.language.this",
-        "variable.parameter.function.language.special"
+        "variable.parameter.function.language.special",
+        "keyword.other.definition"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1933,7 +1935,7 @@
     },
     {
       "name": "text",
-      "scope": ["text"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""


### PR DESCRIPTION
This commit enhances the Calmppuccin themes with improved highlighting for editorconfig files and keywords, and adds the `source.ignore` scope to the text color rule.

The following changes were made:

- Added scope `entity.name.section.group-title.editorconfig` to improve highlighting of group titles in editorconfig files.
- Added scope `keyword.other.definition` to improve keyword highlighting.
- Added `source.ignore` scope to the "text" color rule to style ignored files (e.g. .gitignore).