### PR TITLE
feat: release v1.3.7 with editorconfig and ignore file highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.6] - 2025-05-17
+
+- Added `entity.name.section.group-title.editorconfig` and `keyword.other.definition` to the keyword scope for .ediotrconfig highlighting
+- Added `source.ignore` to the text scope for igonre file highlighting (e.g. .gitignore)
+
 ## [1.3.6] - 2025-05-16
 
 - Added scopes for log files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This commit releases version 1.3.7 of the Calmppuccin theme, which includes the following changes:

- Added `entity.name.section.group-title.editorconfig` and `keyword.other.definition` to the keyword scope for .editorconfig highlighting.
- Added `source.ignore` to the text scope for ignore file highlighting (e.g. .gitignore).
- Updated package version to 1.3.7.