### PR TITLE
feat(themes): enhance shell and dockerfile syntax highlighting

### DIFF
--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#92b9f8",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b9b0e9",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#2975af",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#8046cc",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb4f0",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b8b0e4",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#8eb2eb",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b6afe0",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#89abe2",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#b0a9d6",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
@@ -885,7 +885,9 @@
         "source.tf support.class",
         "support.function",
         "support.function.construct.",
-        "meta.group.simple.subexpression.powershell"
+        "meta.group.simple.subexpression.powershell",
+        "keyword.other.special-method",
+        "entity.name.command.shell"
       ],
       "settings": {
         "foreground": "#7d98c4",
@@ -1079,7 +1081,22 @@
         "variable.language.this",
         "variable.language.this",
         "variable.parameter.function.language.special",
-        "keyword.other.definition"
+        "keyword.other.definition",
+        "keyword.control.shell",
+        "keyword.control.then.shell",
+        "keyword.control.fi.shell",
+        "keyword.control.for.shell",
+        "keyword.control.in.shell",
+        "keyword.control.while.shell",
+        "keyword.control.if.shell",
+        "keyword.control.then.shell",
+        "keyword.control.else.shell",
+        "keyword.control.elif.shell",
+        "keyword.control.do.shell",
+        "keyword.control.done.shell",
+        "keyword.control.case.shell",
+        "keyword.control.esac.shell",
+        "keyword.control.select.shell"
       ],
       "settings": {
         "foreground": "#9491b3",
@@ -1935,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore"],
+      "scope": ["text", "source.ignore", "source.dockerfile"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""


### PR DESCRIPTION
This commit improves syntax highlighting for shell scripts and Dockerfiles across all Calmppuccin themes.

- Added highlighting for shell control flow keywords (if, then, else, for, while, case, etc.)
- Added highlighting for special methods and shell commands
- Included `source.dockerfile` in the scope for text highlighting to improve Dockerfile readability.