### PR TITLE
feat: remove `source.dockerfile` scope from themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.9] - 2025-06-09
+
+- Removed `source.dockerfile` because of inconsistencies.
+
 ## [1.3.8] - 2025-06-09
 
 - Added highlighting for shell control flow keywords (if, then, else, for, while, case, etc.)highlighting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "license": "MIT",
       "engines": {
         "vscode": "^1.99.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "./assets/images/logo/icon.png",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {

--- a/themes/frappe/calmppuccin-frappe-blue-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-blue-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-flamingo-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-green-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-green-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-lavender-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-maroon-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-mauve-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-peach-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-peach-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-pink-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-pink-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-red-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-red-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-rosewater-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sapphire-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-sky-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-sky-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-teal-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-teal-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
+++ b/themes/frappe/calmppuccin-frappe-yellow-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0dbe9",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-blue-color-theme.json
+++ b/themes/latte/calmppuccin-latte-blue-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-flamingo-color-theme.json
+++ b/themes/latte/calmppuccin-latte-flamingo-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-green-color-theme.json
+++ b/themes/latte/calmppuccin-latte-green-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-lavender-color-theme.json
+++ b/themes/latte/calmppuccin-latte-lavender-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-maroon-color-theme.json
+++ b/themes/latte/calmppuccin-latte-maroon-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-mauve-color-theme.json
+++ b/themes/latte/calmppuccin-latte-mauve-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-peach-color-theme.json
+++ b/themes/latte/calmppuccin-latte-peach-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-pink-color-theme.json
+++ b/themes/latte/calmppuccin-latte-pink-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-red-color-theme.json
+++ b/themes/latte/calmppuccin-latte-red-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-rosewater-color-theme.json
+++ b/themes/latte/calmppuccin-latte-rosewater-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-sapphire-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sapphire-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-sky-color-theme.json
+++ b/themes/latte/calmppuccin-latte-sky-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-teal-color-theme.json
+++ b/themes/latte/calmppuccin-latte-teal-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/latte/calmppuccin-latte-yellow-color-theme.json
+++ b/themes/latte/calmppuccin-latte-yellow-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#2ba3d3",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-blue-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-flamingo-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-green-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-lavender-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-maroon-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-mauve-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-peach-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-pink-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-red-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-rosewater-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sapphire-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-sky-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-teal-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
+++ b/themes/macchiato/calmppuccin-macchiato-yellow-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a0d6e2",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-blue-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-blue-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-flamingo-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-green-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-green-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-lavender-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-maroon-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-mauve-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-peach-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-peach-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-pink-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-pink-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-red-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-red-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-rosewater-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sapphire-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-sky-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-sky-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-teal-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-teal-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
+++ b/themes/mocha/calmppuccin-mocha-yellow-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#a1d4df",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-blue-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-flamingo-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-green-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-lavender-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-maroon-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-mauve-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-peach-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-pink-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-red-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-rosewater-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sapphire-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-sky-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-teal-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
+++ b/themes/nitro-cold-brew/calmppuccin-nitro-cold-brew-yellow-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#98c7d1",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-blue-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-flamingo-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-green-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-lavender-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-maroon-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-mauve-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-peach-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-pink-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-red-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-rosewater-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sapphire-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-sky-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-teal-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""

--- a/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
+++ b/themes/oledppuccin/calmppuccin-oledppuccin-yellow-color-theme.json
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "text",
-      "scope": ["text", "source.ignore", "source.dockerfile"],
+      "scope": ["text", "source.ignore"],
       "settings": {
         "foreground": "#8db4bd",
         "fontStyle": ""


### PR DESCRIPTION
This commit removes the `source.dockerfile` scope from the text highlighting in all Calmppuccin themes.

- Removed `source.dockerfile` from the scope of the "text" name in all color themes due to inconsistencies.
- Updated the version number to 1.3.9 in `package.json` and `package-lock.json`.
- Updated CHANGELOG.md to reflect the removal of `source.dockerfile`.