### PR TITLE
ci(release): add automated marketplace publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Publish to VS Marketplace
+
+# This workflow runs only when a push happens on the main branch.
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    # Using the latest version of Ubuntu as the operating system for the job.
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Checks out the repository code so the workflow can access it.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 2. Set up Node.js, which is required to run npm and vsce.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # 3. Install all the dependencies from package-lock.json.
+      # Using 'npm ci' is faster and more reliable for CI environments than 'npm install'.
+      - name: Install dependencies
+        run: npm ci
+
+      # 4. Publish the extension to the Marketplace.
+      - name: Publish to VS Marketplace
+        run: npx vsce publish -p ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the process of publishing the extension to the Visual Studio Marketplace.

The new workflow, defined in `.github/workflows/release.yml`, includes the following features:

- **Trigger on Main:** The pipeline is configured to run automatically only on pushes to the `main` branch, ensuring that only production-ready code is released.
- **Automated Build:** It sets up a clean Node.js environment, installs dependencies using `npm ci`, and runs the extension's build scripts.
- **Secure Publishing:** It uses `vsce publish` with a `VSCE_PAT` secret (stored in GitHub Actions) to securely authenticate with the marketplace and publish the new version.

This change eliminates the need for manual publishing, ensuring consistent and reliable releases.