### PR TITLE
feat: Add customization UI for Calmppuccin theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.4.5] - 2025-08-07
+
+- **Feature**: Added a custom settings UI built with a webview. Users can now run the `Calmppuccin: Customize Theme` command to open a graphical editor.
+- **Feature**: The new customization UI allows users to change the accent color and all granular font styles from a single, user-friendly panel.
+- **Improvement**: Reworked the extension's settings in the standard VS Code UI. The font style settings are now bundled into a single expandable object, and a new clickable link is provided to guide users to the custom UI.
+- **Fix**: Implemented state persistence for the custom UI, so its content is no longer lost when switching tabs.
+- **Fix**: Corrected the communication logic between the webview and the extension, ensuring that changes made in the UI are correctly saved and trigger a theme regeneration.
+
 ## [1.4.4] - 2025-08-06
 
 - **Feature**: Added highly customizable font style settings. Users can now choose between `none`, `italic`, `bold`, `italic bold` and `underline` for various syntax elements like comments, keywords, classes, and more, providing granular control over the syntax font style.

--- a/README.md
+++ b/README.md
@@ -56,27 +56,47 @@ enter `Calmppuccin`, locate the extension in the results, and select Install to 
 
 ## Customization
 
-You can easily tailor Calmppuccin to fit your personal preferences for both accent colors and font styles.
+You can easily tailor Calmppuccin to fit your personal preferences. Choose the method that works best for you.
 
-### 1. Using the Settings Menu (Recommended)
+### 1. Using the Customization UI (Recommended)
+
+This is the easiest and recommended way to configure everything in one place. You can open the custom UI in two main ways:
+
+- **Via the Command Palette (Quickest Method):**
+
+1. Open the Command Palette (`Ctrl` + `Shift` + `P`, `Cmd` + `Shift` + `P` or `F1`).
+2. Type `Calmppuccin` and select Calmppuccin: Customize Theme.
+
+- **Via the Settings Menu:**
+
+1. Open VS Code Settings (`Crtl` + `,`)
+2. Seach for `Calmppuccin`.
+3. Find the setting titled `Calmppuccin: Open Customization UI` and click the link within its description to open the panel.
+
+Either method will open a new panel where you can visually change the Accent Color and all Font Styles. Changes are\
+saved automatically, and a notification will appear prompting you to reload VS Code to apply them.
+
+### 2. Using the Standard Settings UI
+
+This is a quick way to change **only the accent color**.
 
 1. Open your VS Code Settings (`Ctrl` + `,`).
-2. In the search bar, type `Calmppuccin`.
-3. You will see all the available settings, including **"Calmppuccin: Accent"** and the various **"Calmppuccin: ... Font Style"** options.
-4. Select your desired accent color and font styles from the dropdown menus.
-5. A notification will prompt you to reload VS Code. Click **"Reload Window"** to apply the changes.
+2. In the search bar, type `Calmppuccin Accent`.
+3. Use the dropdown menu to select your desired accent color.
 
-### 2. Editing `settings.json`
+### 3. Editing `settings.json` (For Power Users)
 
-For those who prefer editing JSON directly, you can add the following lines to your `settings.json` file.
+For those who prefer editing JSON directly, you can modify your settings.json file.
+
+#### 🎨 Accent Color
+
+Add the following line to set your accent color. Replace `mauve` with any of the available options below.
 
 ```json
 "calmppuccin.accent": "mauve"
 ```
 
-Replace "mauve" with any of the available accent options below.
-
-#### 🎨 Accents
+##### **Available Accents:**
 
 - `blue`
 - `flamingo`
@@ -95,16 +115,28 @@ Replace "mauve" with any of the available accent options below.
 
 #### ✒️ Font Styles
 
-You can control the font style for various syntax elements. Here is an example of how to change the style for comments and keywords:
+You can control the font style for each syntax element directly in the JSON.
+
+A helpful shortcut:
+
+1. Go to the standard Settings UI and search for `Calmppuccin: Font Styles`.
+2. Click the `Edit in settings.json` link.
+3. This will automatically add the entire `calmppuccin.fontStyles` object with all default values to your file, making it easy to edit.
+
+Here is an example of the structure:
 
 ```json
-"calmppuccin.commentFontStyle": "italic",
-"calmppuccin.keywordFontStyle": "bold"
+"calmppuccin.fontStyles": {
+  "commentFontStyle": "italic",
+  "variableFontStyle": "none",
+  "keywordFontStyle": "none",
+  // ... and so on for all other elements
+}
 ```
 
-Each font style setting can be configured with one of the following options:
+##### **Available Font Style Options:**
 
-- "" (for no font style)
+- `none` (will be replaced with an empty string)
 - `italic`
 - `bold`
 - `italic bold`
@@ -125,8 +157,8 @@ Also with new theme variants like `Nitro Cold Brew` (even darker and more subdue
 - **Aesthetic Balance:** Strikes the perfect balance between functionality and beauty,\
 blending soothing colors with practical design.
 
-- **Customizable:** Offers flexibility to tweak background colors, text shades, and\
-accents to suit individual preferences.
+- **Highly Customizable:** Personalize your coding environment by selecting from a palette of\
+14 accent colors and applying unique font styles (like italic or bold) to individual syntax elements.
 
 ---
 

--- a/extension.ts
+++ b/extension.ts
@@ -7,6 +7,7 @@
 import * as vscode from "vscode";
 import { buildAllFlavors } from "./build";
 import * as C from "./src/constants";
+import { SettingsPanel } from "./src/SettingsPanel";
 
 /**
  * Maps Calmppuccin theme flavors to their corresponding Catppuccin Icon flavors.
@@ -66,27 +67,13 @@ async function syncIconFlavor() {
 export function activate(context: vscode.ExtensionContext) {
   console.log("Calmppuccin theme is now active!");
 
-  // Dynamically get all configuration keys from package.json
-  const extensionConfig = vscode.extensions.getExtension("kenan-salar.calmppuccin-vscode")?.packageJSON;
-  const configKeys = Object.keys(extensionConfig?.contributes?.configuration?.properties ?? {});
-
   const regenerateThemesCommand = vscode.commands.registerCommand(C.REGENERATE_COMMAND_ID, async () => {
     try {
       const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
       const accent = config.get<string>(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT);
+      const fontStyles = config.get<{ [key: string]: string }>("fontStyles");
 
-      // Dynamically build the settings object from the user's configuration
-      const editorSettings: { [key: string]: any } = {};
-      for (const key of configKeys) {
-        const settingName = key.split(".")[1];
-        // This is the fix: only add the setting if it's not the accent color.
-        if (settingName && settingName !== C.CONFIG_KEY_ACCENT) {
-          editorSettings[settingName] = config.get(settingName);
-        }
-      }
-
-      // Pass the dynamically created settings object to the build function
-      await buildAllFlavors(accent, editorSettings);
+      await buildAllFlavors(accent, fontStyles || {});
 
       const selection = await vscode.window.showInformationMessage(C.INFO_MESSAGE(accent), C.RELOAD_ACTION);
 
@@ -108,19 +95,25 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  // The listener now checks against the dynamic list of settings.
-  const settingsChangeListener = vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
-    const affectsOurSettings = configKeys.some((key) => event.affectsConfiguration(key));
+  const customizeCommand = vscode.commands.registerCommand("calmppuccin.customize", () => {
+    SettingsPanel.createOrShow(context.extensionPath);
+  });
 
-    if (affectsOurSettings) {
+  const settingsChangeListener = vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+    if (
+      event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`) ||
+      event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.fontStyles`)
+    ) {
       vscode.commands.executeCommand(C.REGENERATE_COMMAND_ID);
     }
+
     if (event.affectsConfiguration("workbench.colorTheme")) {
       syncIconFlavor();
     }
   });
 
-  context.subscriptions.push(regenerateThemesCommand, settingsChangeListener);
+  context.subscriptions.push(regenerateThemesCommand, settingsChangeListener, customizeCommand);
+
   syncIconFlavor();
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",
@@ -634,16 +634,16 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.195",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.195.tgz",
-      "integrity": "sha512-URclP0iIaDUzqcAyV1v2PgduJ9N0IdXmWsnPzPfelvBmjmZzEy6xJcjb1cXj+TbYqXgtLrjHEoaSIdTYhw4ezg==",
+      "version": "1.5.198",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.198.tgz",
+      "integrity": "sha512-G5COfnp3w+ydVu80yprgWSfmfQaYRh9DOxfhAxstLyetKaLyl55QrNjx8C38Pc/C+RaDmb1M0Lk8wPEMQ+bGgQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "assets/images/logo/icon.png",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {
@@ -65,6 +65,13 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "calmppuccin.customize",
+        "title": "Customize Theme",
+        "category": "Calmppuccin"
+      }
+    ],
     "themes": [
       {
         "label": "Calmppuccin Macchiato",
@@ -121,556 +128,394 @@
             "lavender"
           ]
         },
-        "calmppuccin.commentFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for comments.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
+        "calmppuccin.openCustomizationUI": {
+          "type": "null",
+          "markdownDescription": "Click the link to open the graphical UI for customizing colors and font styles. [**Open Customization UI**](command:calmppuccin.customize)"
         },
-        "calmppuccin.variableFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for variables.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.keywordFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for keywords.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.namespaceFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for namespaces.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.namespaceAttributeFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for namespace attributes.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.moduleFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for modules.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.annotationFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for annotations.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.classFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for classes.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.interfaceFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for interfaces.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.structFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for structs.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.enumFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for enums.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.enumMemberFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for enum members.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.fieldAndAttributeFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for fields and attributes.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.attributeBracketFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for attribute brackets.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.propertyFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for properties.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.propertyReadOnlyFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for read only properties.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.functionAndMethodFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for functions and methods.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.extensionMethodFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for extension methods.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.delegateFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for delegates.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.eventFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for events.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.parameterFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for parameters.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.typeParameterFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for type parameters.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.numberAndConstantFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for numbers and constants.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.operatorFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for operators.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.operatorOverloadFontStyle": {
-          "type": "string",
-          "default": "bold",
-          "description": "Set the font style for overload operators.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.punctuationFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for punctuations.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.stringFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for strings.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.stringVerbatimFontStyle": {
-          "type": "string",
-          "default": "italic",
-          "description": "Set the font style for verbatim strings.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
-        },
-        "calmppuccin.textFontStyle": {
-          "type": "string",
-          "default": "none",
-          "description": "Set the font style for text.",
-          "enum": [
-            "none",
-            "italic",
-            "bold",
-            "italic bold",
-            "underline"
-          ],
-          "enumDescriptions": [
-            "No font style",
-            "Italic font style",
-            "Bold font style",
-            "Italic and bold font style",
-            "Underline font style"
-          ]
+        "calmppuccin.fontStyles": {
+          "type": "object",
+          "description": "The raw JSON configuration for font styles. For a better experience, use the Customization UI.",
+          "default": {
+            "commentFontStyle": "italic",
+            "variableFontStyle": "none",
+            "keywordFontStyle": "none",
+            "namespaceFontStyle": "none",
+            "namespaceAttributeFontStyle": "italic",
+            "moduleFontStyle": "none",
+            "annotationFontStyle": "italic",
+            "classFontStyle": "none",
+            "interfaceFontStyle": "none",
+            "structFontStyle": "none",
+            "enumFontStyle": "none",
+            "enumMemberFontStyle": "italic",
+            "fieldAndAttributeFontStyle": "none",
+            "attributeBracketFontStyle": "italic",
+            "propertyFontStyle": "none",
+            "propertyReadOnlyFontStyle": "italic",
+            "functionAndMethodFontStyle": "none",
+            "extensionMethodFontStyle": "italic",
+            "delegateFontStyle": "none",
+            "eventFontStyle": "none",
+            "parameterFontStyle": "italic",
+            "typeParameterFontStyle": "italic",
+            "numberAndConstantFontStyle": "none",
+            "operatorFontStyle": "none",
+            "operatorOverloadFontStyle": "bold",
+            "punctuationFontStyle": "none",
+            "stringFontStyle": "none",
+            "stringVerbatimFontStyle": "italic",
+            "textFontStyle": "none"
+          },
+          "properties": {
+            "commentFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for comments.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "variableFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for variables.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "keywordFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for keywords.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "namespaceFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for namespaces.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "namespaceAttributeFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for namespace attributes.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "moduleFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for modules.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "annotationFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for annotations.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "classFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for classes.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "interfaceFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for interfaces.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "structFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for structs.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "enumFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for enums.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "enumMemberFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for enum members.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "fieldAndAttributeFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for fields and attributes.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "attributeBracketFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for attribute brackets.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "propertyFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for properties.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "propertyReadOnlyFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for read only properties.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "functionAndMethodFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for functions and methods.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "extensionMethodFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for extension methods.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "delegateFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for delegates.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "eventFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for events.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "parameterFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for parameters.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "typeParameterFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for type parameters.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "numberAndConstantFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for numbers and constants.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "operatorFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for operators.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "operatorOverloadFontStyle": {
+              "type": "string",
+              "default": "bold",
+              "description": "Set the font style for overload operators.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "punctuationFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for punctuations.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "stringFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for strings.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "stringVerbatimFontStyle": {
+              "type": "string",
+              "default": "italic",
+              "description": "Set the font style for verbatim strings.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "textFontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for text.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            }
+          }
         }
       }
     }

--- a/src/SettingsPanel.ts
+++ b/src/SettingsPanel.ts
@@ -1,0 +1,132 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import * as C from "./constants";
+
+export class SettingsPanel {
+  public static currentPanel: SettingsPanel | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _extensionPath: string;
+  private _disposables: vscode.Disposable[] = [];
+
+  private constructor(panel: vscode.WebviewPanel, extensionPath: string) {
+    this._panel = panel;
+    this._extensionPath = extensionPath;
+
+    // Set the webview's initial html content
+    this._update();
+
+    // Listen for when the panel is disposed
+    // This happens when the user closes the panel or when the panel is closed programmatically
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    // Update the content based on view changes
+    this._panel.onDidChangeViewState(
+      (e) => {
+        if (this._panel.visible) {
+          this._update();
+        }
+      },
+      null,
+      this._disposables
+    );
+
+    // Handle messages from the webview
+    this._panel.webview.onDidReceiveMessage(
+      async (message) => {
+        const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
+        switch (message.command) {
+          case "updateSetting":
+            const { key, value } = message;
+            const fontStyles = config.get("fontStyles", {});
+            const newFontStyles = { ...fontStyles, [key]: value };
+            await config.update("fontStyles", newFontStyles, vscode.ConfigurationTarget.Global);
+            return;
+          case "updateAccent":
+            await config.update(C.CONFIG_KEY_ACCENT, message.value, vscode.ConfigurationTarget.Global);
+            return;
+        }
+      },
+      null,
+      this._disposables
+    );
+  }
+
+  public static createOrShow(extensionPath: string) {
+    const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined;
+
+    // If we already have a panel, show it.
+    if (SettingsPanel.currentPanel) {
+      SettingsPanel.currentPanel._panel.reveal(column);
+      return;
+    }
+
+    // Otherwise, create a new panel.
+    const panel = vscode.window.createWebviewPanel(
+      "calmppuccinSettings",
+      "Calmppuccin Settings",
+      column || vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        localResourceRoots: [
+          vscode.Uri.file(path.join(extensionPath, "dist")),
+          vscode.Uri.file(path.join(extensionPath, "webview")),
+        ],
+        retainContextWhenHidden: true,
+      }
+    );
+
+    SettingsPanel.currentPanel = new SettingsPanel(panel, extensionPath);
+  }
+
+  private _update() {
+    const webview = this._panel.webview;
+    this._panel.title = "Calmppuccin Customization";
+    webview.html = this._getHtmlForWebview();
+
+    const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
+    const fontStyles = config.get("fontStyles");
+    const currentAccent = config.get(C.CONFIG_KEY_ACCENT);
+
+    const extensionConfig = vscode.extensions.getExtension("kenan-salar.calmppuccin-vscode")?.packageJSON;
+    const accentOptions =
+      extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`]?.enum ??
+      [];
+
+    webview.postMessage({
+      command: "loadSettings",
+      settings: {
+        fontStyles,
+        currentAccent,
+        accentOptions,
+      },
+    });
+  }
+
+  private _getHtmlForWebview(): string {
+    const htmlPath = path.join(this._extensionPath, "webview", "index.html");
+    let htmlContent = fs.readFileSync(htmlPath, "utf8");
+
+    const scriptPath = vscode.Uri.file(path.join(this._extensionPath, "dist", "webview.js"));
+    const scriptUri = this._panel.webview.asWebviewUri(scriptPath);
+
+    const stylePath = vscode.Uri.file(path.join(this._extensionPath, "webview", "style.css"));
+    const styleUri = this._panel.webview.asWebviewUri(stylePath);
+
+    htmlContent = htmlContent.replace("webview.js", scriptUri.toString());
+    htmlContent = htmlContent.replace("style.css", styleUri.toString());
+
+    return htmlContent;
+  }
+
+  public dispose() {
+    SettingsPanel.currentPanel = undefined;
+    this._panel.dispose();
+    while (this._disposables.length) {
+      const x = this._disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,5 +54,27 @@ const configs = [
       ],
     },
   },
+  {
+    target: "web",
+    mode: "production",
+    entry: "./webview/main.ts", // Entry point for the webview script
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      filename: "webview.js", // Output file
+    },
+    resolve: {
+      extensions: [".ts", ".js"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: ["ts-loader"],
+        },
+      ],
+    },
+    devtool: "source-map",
+  },
 ];
 module.exports = configs;

--- a/webview/index.html
+++ b/webview/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <title>Calmppuccin Customization</title>
+</head>
+<body>
+    <h1>Calmppuccin Customization</h1>
+    <p>Changes are saved automatically. A reload is required to apply them.</p>
+
+    <div id="accent-container" class="settings-section">
+        <h2>Accent Color</h2>
+        </div>
+
+    <div id="font-styles-container" class="settings-section">
+      <h2>Font Styles</h2>
+      <div id="settings-container">
+          </div>
+    </div>
+    
+    <script src="webview.js"></script>
+</body>
+</html>

--- a/webview/main.ts
+++ b/webview/main.ts
@@ -1,0 +1,79 @@
+interface VsCodeApi {
+  postMessage(message: any): void;
+}
+declare function acquireVsCodeApi(): VsCodeApi;
+const vscode = acquireVsCodeApi();
+
+function initialize() {
+  const accentContainer = document.getElementById("accent-container");
+  const settingsContainer = document.getElementById("settings-container");
+  if (!settingsContainer || !accentContainer) return;
+
+  const fontStyleOptions = ["none", "italic", "bold", "italic bold", "underline"];
+
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message.command === "loadSettings") {
+      const { currentAccent, accentOptions, fontStyles } = message.settings;
+
+      // --- 1. Render Accent Color Dropdown ---
+      accentContainer.innerHTML = ""; // Clear previous
+      const accentLabel = document.createElement("label");
+      accentLabel.textContent = "Accent Color:";
+      const accentSelect = document.createElement("select");
+
+      accentOptions.forEach((option: string) => {
+        const optionElement = document.createElement("option");
+        optionElement.value = option;
+        optionElement.textContent = option;
+        if (currentAccent === option) {
+          optionElement.selected = true;
+        }
+        accentSelect.appendChild(optionElement);
+      });
+
+      accentSelect.addEventListener("change", (e) => {
+        const newValue = (e.target as HTMLSelectElement).value;
+        vscode.postMessage({ command: "updateAccent", value: newValue });
+      });
+
+      accentContainer.appendChild(accentLabel);
+      accentContainer.appendChild(accentSelect);
+
+      // --- 2. Render Font Style Dropdowns ---
+      settingsContainer.innerHTML = ""; // Clear previous
+      for (const key in fontStyles) {
+        const label = document.createElement("label");
+        label.textContent =
+          key
+            .replace(/([A-Z])/g, " $1")
+            .replace("Font Style", "")
+            .trim() + ":";
+        label.htmlFor = key;
+
+        const select = document.createElement("select");
+        select.id = key;
+
+        fontStyleOptions.forEach((option) => {
+          const optionElement = document.createElement("option");
+          optionElement.value = option;
+          optionElement.textContent = option;
+          if (fontStyles[key] === option) {
+            optionElement.selected = true;
+          }
+          select.appendChild(optionElement);
+        });
+
+        select.addEventListener("change", (e) => {
+          const newValue = (e.target as HTMLSelectElement).value;
+          vscode.postMessage({ command: "updateSetting", key: key, value: newValue });
+        });
+
+        settingsContainer.appendChild(label);
+        settingsContainer.appendChild(select);
+      }
+    }
+  });
+}
+
+initialize();

--- a/webview/style.css
+++ b/webview/style.css
@@ -1,0 +1,38 @@
+body {
+    background-color: var(--vscode-editor-background);
+    color: var(--vscode-editor-foreground);
+    font-family: var(--vscode-font-family);
+    padding: 0 20px;
+}
+
+#settings-container {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 10px 20px;
+    align-items: center;
+    margin-top: 20px;
+}
+
+label {
+    font-weight: bold;
+    text-transform: capitalize;
+}
+
+select {
+    width: 100%;
+    padding: 5px;
+    background-color: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border);
+    border-radius: 4px;
+}
+
+.settings-section {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid var(--vscode-editor-widget-border);
+}
+
+h2 {
+    margin-top: 0;
+}


### PR DESCRIPTION
- Introduced a new SettingsPanel for customizing font styles and accent color.
- Added a webview for user-friendly settings management.
- Updated extension activation to include a command for opening the customization UI.
- Refactored theme regeneration logic to utilize new font styles configuration.
- Enhanced package.json to include new commands and settings for font styles.
- Updated webpack configuration to bundle webview scripts.
- Incremented version to 1.4.5 and updated package-lock.json.