### PR TITLE
Refactor: Centralize magic strings into constants

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -72,8 +72,8 @@ export function activate(context: vscode.ExtensionContext) {
       const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
       const accentSetting = config.get<string>(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT);
       const customAccent = config.get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
-      const fontStyles = config.get<{ [key: string]: string }>("fontStyles");
-      const syntaxOverrides = config.get<object>("syntaxOverrides", {});
+      const fontStyles = config.get<{ [key: string]: string }>(C.CONFIG_KEY_FONT_STYLES);
+      const syntaxOverrides = config.get<object>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {});
 
       const accentValue = accentSetting === "custom" ? customAccent : accentSetting;
 
@@ -99,16 +99,16 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  const customizeCommand = vscode.commands.registerCommand("calmppuccin.customize", () => {
+  const customizeCommand = vscode.commands.registerCommand(C.CUSTOMIZE_COMMAND_ID, () => {
     SettingsPanel.createOrShow(context);
   });
 
   const settingsChangeListener = vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
     if (
       event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`) ||
-      event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.fontStyles`) ||
+      event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_FONT_STYLES}`) ||
       event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_CUSTOM_ACCENT}`) ||
-      event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.syntaxOverrides`)
+      event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_SYNTAX_OVERRIDES}`)
     ) {
       vscode.commands.executeCommand(C.REGENERATE_COMMAND_ID);
     }

--- a/src/SettingsPanel.ts
+++ b/src/SettingsPanel.ts
@@ -61,46 +61,46 @@ export class SettingsPanel {
         const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
 
         switch (message.command) {
-          case "updateSetting": {
+          case C.WEBVIEW_COMMANDS.UPDATE_SETTING: {
             const { key, value } = message;
-            const fontStyles = config.get("fontStyles", {});
-            await config.update("fontStyles", { ...fontStyles, [key]: value }, vscode.ConfigurationTarget.Global);
+            const fontStyles = config.get(C.CONFIG_KEY_FONT_STYLES, {});
+            await config.update(C.CONFIG_KEY_FONT_STYLES, { ...fontStyles, [key]: value }, vscode.ConfigurationTarget.Global);
             return;
           }
-          case "resetFontStyle": {
+          case C.WEBVIEW_COMMANDS.RESET_FONT_STYLE: {
             const { key } = message;
-            const fontStyles = { ...config.get<any>("fontStyles", {}) };
+            const fontStyles = { ...config.get<any>(C.CONFIG_KEY_FONT_STYLES, {}) };
             delete fontStyles[key];
 
             // If the object is now empty, update with `undefined` to remove it from settings.json
             const finalFontStyles = Object.keys(fontStyles).length === 0 ? undefined : fontStyles;
 
-            await config.update("fontStyles", finalFontStyles, vscode.ConfigurationTarget.Global);
+            await config.update(C.CONFIG_KEY_FONT_STYLES, finalFontStyles, vscode.ConfigurationTarget.Global);
             return;
           }
-          case "updateAccent":
+          case C.WEBVIEW_COMMANDS.UPDATE_ACCENT:
             await config.update(C.CONFIG_KEY_ACCENT, message.value, vscode.ConfigurationTarget.Global);
             return;
-          case "updateCustomAccent":
+          case C.WEBVIEW_COMMANDS.UPDATE_CUSTOM_ACCENT:
             await config.update(C.CONFIG_KEY_CUSTOM_ACCENT, message.value, vscode.ConfigurationTarget.Global);
             return;
-          case "updateSyntaxColor": {
+          case C.WEBVIEW_COMMANDS.UPDATE_SYNTAX_COLOR: {
             const { flavor, key, value } = message;
             // Create a deep copy to safely mutate
-            const overrides = JSON.parse(JSON.stringify(config.get<any>("syntaxOverrides", {})));
+            const overrides = JSON.parse(JSON.stringify(config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {})));
 
             if (!overrides[flavor]) {
               overrides[flavor] = {};
             }
             overrides[flavor][key] = value;
 
-            await config.update("syntaxOverrides", overrides, vscode.ConfigurationTarget.Global);
+            await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, overrides, vscode.ConfigurationTarget.Global);
             return;
           }
-          case "resetSyntaxColor": {
+          case C.WEBVIEW_COMMANDS.RESET_SYNTAX_COLOR: {
             const { flavor, key } = message;
             // Create a deep copy to safely mutate
-            const overrides = JSON.parse(JSON.stringify(config.get<any>("syntaxOverrides", {})));
+            const overrides = JSON.parse(JSON.stringify(config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {})));
 
             if (overrides[flavor]?.[key]) {
               delete overrides[flavor][key];
@@ -112,13 +112,13 @@ export class SettingsPanel {
               // If the object is empty, update with `undefined` to remove it from settings.json
               const finalOverrides = Object.keys(overrides).length === 0 ? undefined : overrides;
 
-              await config.update("syntaxOverrides", finalOverrides, vscode.ConfigurationTarget.Global);
+              await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, finalOverrides, vscode.ConfigurationTarget.Global);
             }
             return;
           }
-          case "resetAll": {
-            await config.update("fontStyles", undefined, vscode.ConfigurationTarget.Global);
-            await config.update("syntaxOverrides", undefined, vscode.ConfigurationTarget.Global);
+          case C.WEBVIEW_COMMANDS.RESET_ALL: {
+            await config.update(C.CONFIG_KEY_FONT_STYLES, undefined, vscode.ConfigurationTarget.Global);
+            await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, undefined, vscode.ConfigurationTarget.Global);
             await config.update(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT, vscode.ConfigurationTarget.Global);
             this._update();
             return;
@@ -138,8 +138,8 @@ export class SettingsPanel {
     }
 
     const panel = vscode.window.createWebviewPanel(
-      "calmppuccinSettings",
-      "Calmppuccin Settings",
+      C.WEBVIEW_COMMANDS.WEBVIEW_ID,
+      C.WEBVIEW_COMMANDS.WEBVIEW_TITLE,
       column || vscode.ViewColumn.One,
       {
         enableScripts: true,
@@ -175,7 +175,7 @@ export class SettingsPanel {
     if (!this._panel.visible) return;
 
     const webview = this._panel.webview;
-    this._panel.title = "Calmppuccin Customization";
+    this._panel.title = C.WEBVIEW_COMMANDS.WEBVIEW_TITLE;
     webview.html = this._getHtmlForWebview(this._context.extensionPath);
 
     const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
@@ -185,8 +185,8 @@ export class SettingsPanel {
     const activeTheme = workbenchConfig.get<string>("colorTheme", "Calmppuccin Mocha");
     const activeFlavor = this._getFlavorFromTheme(activeTheme);
 
-    const fontStyles = config.get("fontStyles");
-    const syntaxOverrides = config.get<any>("syntaxOverrides", {});
+    const fontStyles = config.get(C.CONFIG_KEY_FONT_STYLES);
+    const syntaxOverrides = config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {});
     const currentAccent = config.get<string>(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT);
     const customAccentColor = config.get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
 
@@ -220,7 +220,7 @@ export class SettingsPanel {
     });
 
     webview.postMessage({
-      command: "loadSettings",
+      command: C.WEBVIEW_COMMANDS.LOAD_SETTINGS,
       settings: {
         activeFlavor,
         syntaxSettings,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,9 @@ export const RELOAD_COMMAND_ID = "workbench.action.reloadWindow";
 export const ICON_THEME_KEY = "workbench.iconTheme";
 export const CATPPUCCIN_ICON_PACK_ID = "catppuccin-";
 export const PANEL_IS_OPEN_KEY = "calmppuccin.panelIsOpen";
+export const CONFIG_KEY_FONT_STYLES = "fontStyles";
+export const CONFIG_KEY_SYNTAX_OVERRIDES = "syntaxOverrides";
+export const CUSTOMIZE_COMMAND_ID = "calmppuccin.customize";
 
 // For build.ts
 export const THEMES_DIR = "themes";
@@ -33,3 +36,17 @@ export const RELOAD_ACTION = "Reload Window";
 export const REPORT_ISSUE_ACTION = "Report Issue";
 export const ERROR_MESSAGE_PREFIX = "Failed to update Calmppuccin themes. Error: ";
 export const REPO_ISSUES_URL = "https://github.com/KenanSalar/calmppuccin-vscode/issues";
+
+// For SettingsPanel.ts
+export const WEBVIEW_COMMANDS = {
+  UPDATE_SETTING: "updateSetting",
+  RESET_FONT_STYLE: "resetFontStyle",
+  UPDATE_ACCENT: "updateAccent",
+  UPDATE_CUSTOM_ACCENT: "updateCustomAccent",
+  UPDATE_SYNTAX_COLOR: "updateSyntaxColor",
+  RESET_SYNTAX_COLOR: "resetSyntaxColor",
+  RESET_ALL: "resetAll",
+  LOAD_SETTINGS: "loadSettings",
+  WEBVIEW_ID: "calmppuccinSettings",
+  WEBVIEW_TITLE: "Calmppuccin Customization",
+} as const;

--- a/webview/main.ts
+++ b/webview/main.ts
@@ -6,22 +6,49 @@ interface VsCodeApi {
 declare function acquireVsCodeApi(): VsCodeApi;
 const vscode = acquireVsCodeApi();
 
+const COMMANDS = {
+  UPDATE_SETTING: "updateSetting",
+  RESET_FONT_STYLE: "resetFontStyle",
+  UPDATE_ACCENT: "updateAccent",
+  UPDATE_CUSTOM_ACCENT: "updateCustomAccent",
+  UPDATE_SYNTAX_COLOR: "updateSyntaxColor",
+  RESET_SYNTAX_COLOR: "resetSyntaxColor",
+  RESET_ALL: "resetAll",
+  LOAD_SETTINGS: "loadSettings",
+};
+
+const DOM_IDS = {
+  ACCENT_CONTAINER: "accent-container",
+  SETTINGS_CONTAINER: "settings-container",
+  CUSTOM_ACCENT_PICKER_CONTAINER: "custom-accent-picker-container",
+  FLAVOR_TITLE: "current-flavor",
+  CUSTOM_ACCENT_PICKER: "custom-accent-picker",
+  CUSTOM_ACCENT_HEX_INPUT: "custom-accent-hex-input",
+  PREVIEW_PANE: "preview-pane",
+  CODE_PREVIEW: "code-preview",
+  RESET_ALL_CONTAINER: "reset-all-container",
+  LANGUAGE_SELECT: "language-select",
+  DIALOG_OVERLAY: "reset-dialog-overlay",
+  CONFIRM_RESET_BUTTON: "dialog-confirm-button",
+  CANCEL_RESET_BUTTON: "dialog-cancel-button",
+};
+
 function initialize() {
-  const accentContainer = document.getElementById("accent-container");
-  const settingsContainer = document.getElementById("settings-container");
-  const customAccentPickerContainer = document.getElementById("custom-accent-picker-container");
-  const flavorTitle = document.getElementById("current-flavor");
-  const customAccentPicker = document.getElementById("custom-accent-picker") as HTMLInputElement;
-  const customAccentHexInput = document.getElementById("custom-accent-hex-input") as HTMLInputElement;
-  const previewPane = document.getElementById("preview-pane");
-  const codePreview = document.getElementById("code-preview");
-  const resetAllContainer = document.getElementById("reset-all-container");
-  const languageSelect = document.getElementById("language-select") as HTMLSelectElement;
+  const accentContainer = document.getElementById(DOM_IDS.ACCENT_CONTAINER);
+  const settingsContainer = document.getElementById(DOM_IDS.SETTINGS_CONTAINER);
+  const customAccentPickerContainer = document.getElementById(DOM_IDS.CUSTOM_ACCENT_PICKER_CONTAINER);
+  const flavorTitle = document.getElementById(DOM_IDS.FLAVOR_TITLE);
+  const customAccentPicker = document.getElementById(DOM_IDS.CUSTOM_ACCENT_PICKER) as HTMLInputElement;
+  const customAccentHexInput = document.getElementById(DOM_IDS.CUSTOM_ACCENT_HEX_INPUT) as HTMLInputElement;
+  const previewPane = document.getElementById(DOM_IDS.PREVIEW_PANE);
+  const codePreview = document.getElementById(DOM_IDS.CODE_PREVIEW);
+  const resetAllContainer = document.getElementById(DOM_IDS.RESET_ALL_CONTAINER);
+  const languageSelect = document.getElementById(DOM_IDS.LANGUAGE_SELECT) as HTMLSelectElement;
 
   // Declarations for the dialog elements
-  const dialogOverlay = document.getElementById("reset-dialog-overlay");
-  const confirmResetButton = document.getElementById("dialog-confirm-button");
-  const cancelResetButton = document.getElementById("dialog-cancel-button");
+  const dialogOverlay = document.getElementById(DOM_IDS.DIALOG_OVERLAY);
+  const confirmResetButton = document.getElementById(DOM_IDS.CONFIRM_RESET_BUTTON);
+  const cancelResetButton = document.getElementById(DOM_IDS.CANCEL_RESET_BUTTON);
 
   if (
     !settingsContainer ||
@@ -94,7 +121,7 @@ function initialize() {
 
   window.addEventListener("message", (event) => {
     const message = event.data;
-    if (message.command === "loadSettings") {
+    if (message.command === COMMANDS.LOAD_SETTINGS) {
       const {
         activeFlavor,
         syntaxSettings,
@@ -141,7 +168,7 @@ function initialize() {
       accentSelect.addEventListener("change", (e) => {
         const newValue = (e.target as HTMLSelectElement).value;
         handleAccentChange(newValue);
-        vscode.postMessage({ command: "updateAccent", value: newValue });
+        vscode.postMessage({ command: COMMANDS.UPDATE_ACCENT, value: newValue });
       });
       accentSelectContainer.appendChild(accentLabel);
       accentSelectContainer.appendChild(accentSelect);
@@ -155,14 +182,14 @@ function initialize() {
         const newValue = (e.target as HTMLInputElement).value;
         customAccentHexInput.value = newValue;
         updateAccentColor(newValue);
-        vscode.postMessage({ command: "updateCustomAccent", value: newValue });
+        vscode.postMessage({ command: COMMANDS.UPDATE_CUSTOM_ACCENT, value: newValue });
       });
       customAccentHexInput.addEventListener("input", (e) => {
         const newValue = (e.target as HTMLInputElement).value;
         if (hex6Regex.test(newValue)) {
           customAccentPicker.value = newValue;
           updateAccentColor(newValue);
-          vscode.postMessage({ command: "updateCustomAccent", value: newValue });
+          vscode.postMessage({ command: COMMANDS.UPDATE_CUSTOM_ACCENT, value: newValue });
         }
       });
 
@@ -191,7 +218,7 @@ function initialize() {
           const newValue = (e.target as HTMLSelectElement).value;
           previewState[key].fontStyle = newValue;
           updatePreviewPane();
-          vscode.postMessage({ command: "updateSetting", key: fontStyleKey, value: newValue });
+          vscode.postMessage({ command: COMMANDS.UPDATE_SETTING, key: fontStyleKey, value: newValue });
         });
 
         const fontResetButton = document.createElement("button");
@@ -201,7 +228,7 @@ function initialize() {
           select.value = defaultFontStyle;
           previewState[key].fontStyle = defaultFontStyle;
           updatePreviewPane();
-          vscode.postMessage({ command: "resetFontStyle", key: fontStyleKey });
+          vscode.postMessage({ command: COMMANDS.RESET_FONT_STYLE, key: fontStyleKey });
         });
 
         const wrapper = document.createElement("div");
@@ -248,7 +275,7 @@ function initialize() {
         // This function ONLY sends the final color to VS Code
         const sendFinalColorToVSCode = () => {
           const finalColor = hexInput.value;
-          vscode.postMessage({ command: "updateSyntaxColor", flavor: activeFlavor, key, value: finalColor });
+          vscode.postMessage({ command: COMMANDS.UPDATE_SYNTAX_COLOR, flavor: activeFlavor, key, value: finalColor });
         };
 
         // Update the live preview instantly on the 'input' event
@@ -273,7 +300,7 @@ function initialize() {
 
           previewState[key].color = defaultColor;
           updatePreviewPane();
-          vscode.postMessage({ command: "resetSyntaxColor", flavor: activeFlavor, key });
+          vscode.postMessage({ command: COMMANDS.RESET_SYNTAX_COLOR, flavor: activeFlavor, key });
         });
 
         topRow.appendChild(colorInput);
@@ -322,7 +349,7 @@ function initialize() {
 
   confirmResetButton.addEventListener("click", () => {
     // Send the reset command and hide the dialog
-    vscode.postMessage({ command: "resetAll" });
+    vscode.postMessage({ command: COMMANDS.RESET_ALL });
     dialogOverlay.classList.add("hidden");
   });
 }


### PR DESCRIPTION
This commit removes hardcoded string literals (magic strings) from the codebase and centralizes them into constant variables to improve maintainability and reduce the risk of typos causing silent failures.

Key changes include:
- Created a `WEBVIEW_COMMANDS` object in `src/constants.ts` to manage all communication commands between the extension and the settings panel.
- Centralized configuration keys like `fontStyles` and `syntaxOverrides` into `src/constants.ts`.
- Added constants for the webview panel's ID, title, and the "customize" command ID.
- Created `COMMANDS` and `DOM_IDS` objects within `webview/main.ts` to manage all DOM selectors and postMessage commands locally.

All relevant files, including `extension.ts`, `SettingsPanel.ts`, and `webview/main.ts`, have been updated to use these new constants, establishing a single source of truth for these values.