### PR TITLE
Refactor: Centralize webview logic into WebviewManager

### DIFF
--- a/src/SettingsPanel.ts
+++ b/src/SettingsPanel.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
-import * as path from "path";
-import * as fs from "fs";
 import * as C from "./constants";
 import palettes from "./palette";
+import { WebviewManager } from "./WebviewManager";
 
 /**
  * An array of syntax keys that are customizable in the UI.
@@ -43,119 +42,82 @@ const customizableSyntaxKeys = [
 ];
 
 export class SettingsPanel {
-  public static currentPanel: SettingsPanel | undefined;
-  private readonly _panel: vscode.WebviewPanel;
+  private static _instance: SettingsPanel | undefined;
   private readonly _context: vscode.ExtensionContext;
-  private _disposables: vscode.Disposable[] = [];
 
-  private constructor(panel: vscode.WebviewPanel, context: vscode.ExtensionContext) {
-    this._panel = panel;
+  private constructor(context: vscode.ExtensionContext) {
     this._context = context;
-
-    this._update();
-    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
-
-    // Listen for messages from the webview to save settings
-    this._panel.webview.onDidReceiveMessage(
-      async (message) => {
-        const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
-
-        switch (message.command) {
-          case C.WEBVIEW_COMMANDS.UPDATE_SETTING: {
-            const { key, value } = message;
-            const fontStyles = config.get(C.CONFIG_KEY_FONT_STYLES, {});
-            await config.update(C.CONFIG_KEY_FONT_STYLES, { ...fontStyles, [key]: value }, vscode.ConfigurationTarget.Global);
-            return;
-          }
-          case C.WEBVIEW_COMMANDS.RESET_FONT_STYLE: {
-            const { key } = message;
-            const fontStyles = { ...config.get<any>(C.CONFIG_KEY_FONT_STYLES, {}) };
-            delete fontStyles[key];
-
-            // If the object is now empty, update with `undefined` to remove it from settings.json
-            const finalFontStyles = Object.keys(fontStyles).length === 0 ? undefined : fontStyles;
-
-            await config.update(C.CONFIG_KEY_FONT_STYLES, finalFontStyles, vscode.ConfigurationTarget.Global);
-            return;
-          }
-          case C.WEBVIEW_COMMANDS.UPDATE_ACCENT:
-            await config.update(C.CONFIG_KEY_ACCENT, message.value, vscode.ConfigurationTarget.Global);
-            return;
-          case C.WEBVIEW_COMMANDS.UPDATE_CUSTOM_ACCENT:
-            await config.update(C.CONFIG_KEY_CUSTOM_ACCENT, message.value, vscode.ConfigurationTarget.Global);
-            return;
-          case C.WEBVIEW_COMMANDS.UPDATE_SYNTAX_COLOR: {
-            const { flavor, key, value } = message;
-            // Create a deep copy to safely mutate
-            const overrides = JSON.parse(JSON.stringify(config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {})));
-
-            if (!overrides[flavor]) {
-              overrides[flavor] = {};
-            }
-            overrides[flavor][key] = value;
-
-            await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, overrides, vscode.ConfigurationTarget.Global);
-            return;
-          }
-          case C.WEBVIEW_COMMANDS.RESET_SYNTAX_COLOR: {
-            const { flavor, key } = message;
-            // Create a deep copy to safely mutate
-            const overrides = JSON.parse(JSON.stringify(config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {})));
-
-            if (overrides[flavor]?.[key]) {
-              delete overrides[flavor][key];
-
-              if (Object.keys(overrides[flavor]).length === 0) {
-                delete overrides[flavor];
-              }
-
-              // If the object is empty, update with `undefined` to remove it from settings.json
-              const finalOverrides = Object.keys(overrides).length === 0 ? undefined : overrides;
-
-              await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, finalOverrides, vscode.ConfigurationTarget.Global);
-            }
-            return;
-          }
-          case C.WEBVIEW_COMMANDS.RESET_ALL: {
-            await config.update(C.CONFIG_KEY_FONT_STYLES, undefined, vscode.ConfigurationTarget.Global);
-            await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, undefined, vscode.ConfigurationTarget.Global);
-            await config.update(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT, vscode.ConfigurationTarget.Global);
-            this._update();
-            return;
-          }
-        }
-      },
-      null,
-      this._disposables
-    );
   }
 
   public static createOrShow(context: vscode.ExtensionContext) {
-    const column = vscode.window.activeTextEditor?.viewColumn;
-    if (SettingsPanel.currentPanel) {
-      SettingsPanel.currentPanel._panel.reveal(column);
-      return;
+    const isFirstCreation = !SettingsPanel._instance;
+
+    if (isFirstCreation) {
+      SettingsPanel._instance = new SettingsPanel(context);
     }
 
-    const panel = vscode.window.createWebviewPanel(
-      C.WEBVIEW_COMMANDS.WEBVIEW_ID,
-      C.WEBVIEW_COMMANDS.WEBVIEW_TITLE,
-      column || vscode.ViewColumn.One,
-      {
-        enableScripts: true,
-        localResourceRoots: [
-          vscode.Uri.file(path.join(context.extensionPath, "dist")),
-          vscode.Uri.file(path.join(context.extensionPath, "webview")),
-        ],
-        retainContextWhenHidden: true,
-      }
-    );
+    WebviewManager.createOrShow(context, SettingsPanel._instance!._handleMessage.bind(SettingsPanel._instance!));
 
-    SettingsPanel.currentPanel = new SettingsPanel(panel, context);
+    if (isFirstCreation) {
+      SettingsPanel._instance!._update();
+    }
   }
 
   public static updateIfVisible() {
-    SettingsPanel.currentPanel?._update();
+    SettingsPanel._instance?._update();
+  }
+
+  private async _handleMessage(message: any) {
+    const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
+
+    switch (message.command) {
+      case C.WEBVIEW_COMMANDS.UPDATE_SETTING: {
+        const { key, value } = message;
+        const fontStyles = config.get(C.CONFIG_KEY_FONT_STYLES, {});
+        await config.update(C.CONFIG_KEY_FONT_STYLES, { ...fontStyles, [key]: value }, vscode.ConfigurationTarget.Global);
+        return;
+      }
+      case C.WEBVIEW_COMMANDS.RESET_FONT_STYLE: {
+        const { key } = message;
+        const fontStyles = { ...config.get<any>(C.CONFIG_KEY_FONT_STYLES, {}) };
+        delete fontStyles[key];
+        const finalFontStyles = Object.keys(fontStyles).length === 0 ? undefined : fontStyles;
+        await config.update(C.CONFIG_KEY_FONT_STYLES, finalFontStyles, vscode.ConfigurationTarget.Global);
+        return;
+      }
+      case C.WEBVIEW_COMMANDS.UPDATE_ACCENT:
+        await config.update(C.CONFIG_KEY_ACCENT, message.value, vscode.ConfigurationTarget.Global);
+        return;
+      case C.WEBVIEW_COMMANDS.UPDATE_CUSTOM_ACCENT:
+        await config.update(C.CONFIG_KEY_CUSTOM_ACCENT, message.value, vscode.ConfigurationTarget.Global);
+        return;
+      case C.WEBVIEW_COMMANDS.UPDATE_SYNTAX_COLOR: {
+        const { flavor, key, value } = message;
+        const overrides = JSON.parse(JSON.stringify(config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {})));
+        if (!overrides[flavor]) overrides[flavor] = {};
+        overrides[flavor][key] = value;
+        await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, overrides, vscode.ConfigurationTarget.Global);
+        return;
+      }
+      case C.WEBVIEW_COMMANDS.RESET_SYNTAX_COLOR: {
+        const { flavor, key } = message;
+        const overrides = JSON.parse(JSON.stringify(config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {})));
+        if (overrides[flavor]?.[key]) {
+          delete overrides[flavor][key];
+          if (Object.keys(overrides[flavor]).length === 0) delete overrides[flavor];
+          const finalOverrides = Object.keys(overrides).length === 0 ? undefined : overrides;
+          await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, finalOverrides, vscode.ConfigurationTarget.Global);
+        }
+        return;
+      }
+      case C.WEBVIEW_COMMANDS.RESET_ALL: {
+        await config.update(C.CONFIG_KEY_FONT_STYLES, undefined, vscode.ConfigurationTarget.Global);
+        await config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, undefined, vscode.ConfigurationTarget.Global);
+        await config.update(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT, vscode.ConfigurationTarget.Global);
+        this._update();
+        return;
+      }
+    }
   }
 
   private _getFlavorFromTheme(themeName: string): string {
@@ -168,58 +130,44 @@ export class SettingsPanel {
         .normalize("NFD")
         .replace(/[\u0300-\u036f]/g, "");
     }
-    return "mocha"; // Default fallback
+    return "mocha";
   }
 
   private _update() {
-    if (!this._panel.visible) return;
-
-    const webview = this._panel.webview;
-    this._panel.title = C.WEBVIEW_COMMANDS.WEBVIEW_TITLE;
-    webview.html = this._getHtmlForWebview(this._context.extensionPath);
+    if (!WebviewManager.currentPanel) return;
 
     const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
     const workbenchConfig = vscode.workspace.getConfiguration("workbench");
     const extensionConfig = vscode.extensions.getExtension("kenan-salar.calmppuccin-vscode")?.packageJSON;
-
     const activeTheme = workbenchConfig.get<string>("colorTheme", "Calmppuccin Mocha");
     const activeFlavor = this._getFlavorFromTheme(activeTheme);
-
     const fontStyles = config.get(C.CONFIG_KEY_FONT_STYLES);
     const syntaxOverrides = config.get<any>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {});
     const currentAccent = config.get<string>(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT);
     const customAccentColor = config.get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
-
     const defaultFontStyles =
-      extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.fontStyles`]?.default ?? {};
+      extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_FONT_STYLES}`]
+        ?.default ?? {};
     const accentOptions =
       extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`]?.enum ??
       [];
-
     const defaultPalette = (palettes as any)[activeFlavor];
     const overridePalette = syntaxOverrides[activeFlavor] || {};
-
     const activeThemeBackgroundColor = defaultPalette.crust;
 
-    // Extract accent colors from the active flavor's palette
     const accentColorPalettes = accentOptions.reduce((acc: any, option: string) => {
-      if (defaultPalette[option]) {
-        acc[option] = defaultPalette[option];
-      }
+      if (defaultPalette[option]) acc[option] = defaultPalette[option];
       return acc;
     }, {});
 
-    const syntaxSettings = customizableSyntaxKeys.map((key) => {
-      const fontStyleKey = `${key}FontStyle`;
-      return {
-        key: key,
-        fontStyle: (fontStyles as any)?.[fontStyleKey] ?? "none",
-        color: overridePalette[key] || defaultPalette[key],
-        defaultColor: defaultPalette[key],
-      };
-    });
+    const syntaxSettings = customizableSyntaxKeys.map((key) => ({
+      key: key,
+      fontStyle: (fontStyles as any)?.[`${key}FontStyle`] ?? "none",
+      color: overridePalette[key] || defaultPalette[key],
+      defaultColor: defaultPalette[key],
+    }));
 
-    webview.postMessage({
+    WebviewManager.currentPanel.postMessage({
       command: C.WEBVIEW_COMMANDS.LOAD_SETTINGS,
       settings: {
         activeFlavor,
@@ -229,31 +177,8 @@ export class SettingsPanel {
         customAccentColor,
         defaultFontStyles,
         activeThemeBackgroundColor,
-        accentColorPalettes, // Pass the accent colors
+        accentColorPalettes,
       },
     });
-  }
-
-  private _getHtmlForWebview(extensionPath: string): string {
-    const htmlPath = path.join(extensionPath, "webview", "index.html");
-    let htmlContent = fs.readFileSync(htmlPath, "utf8");
-
-    // Create URIs for our local scripts and stylesheets
-    const scriptUri = this._panel.webview.asWebviewUri(vscode.Uri.file(path.join(extensionPath, "dist", "webview.js")));
-    const styleUri = this._panel.webview.asWebviewUri(vscode.Uri.file(path.join(extensionPath, "webview", "style.css")));
-
-    // Replace all placeholders in the HTML
-    htmlContent = htmlContent.replace("webview.js", scriptUri.toString());
-    htmlContent = htmlContent.replace("style.css", styleUri.toString());
-
-    return htmlContent;
-  }
-
-  public dispose() {
-    SettingsPanel.currentPanel = undefined;
-    this._panel.dispose();
-    while (this._disposables.length) {
-      this._disposables.pop()?.dispose();
-    }
   }
 }

--- a/src/WebviewManager.ts
+++ b/src/WebviewManager.ts
@@ -1,0 +1,63 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import * as C from "./constants";
+
+export class WebviewManager {
+  public static currentPanel: WebviewManager | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private _disposables: vscode.Disposable[] = [];
+
+  private constructor(context: vscode.ExtensionContext, messageHandler: (message: any) => void) {
+    this._panel = vscode.window.createWebviewPanel(
+      C.WEBVIEW_COMMANDS.WEBVIEW_ID,
+      C.WEBVIEW_COMMANDS.WEBVIEW_TITLE,
+      vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        localResourceRoots: [
+          vscode.Uri.file(path.join(context.extensionPath, "dist")),
+          vscode.Uri.file(path.join(context.extensionPath, "webview")),
+        ],
+        retainContextWhenHidden: true,
+      }
+    );
+
+    this._panel.webview.html = this._getHtmlForWebview(context.extensionPath);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+    this._panel.webview.onDidReceiveMessage(messageHandler, null, this._disposables);
+  }
+
+  public static createOrShow(context: vscode.ExtensionContext, messageHandler: (message: any) => void) {
+    if (WebviewManager.currentPanel) {
+      WebviewManager.currentPanel._panel.reveal(vscode.ViewColumn.One);
+    } else {
+      WebviewManager.currentPanel = new WebviewManager(context, messageHandler);
+    }
+  }
+
+  public postMessage(message: any) {
+    this._panel.webview.postMessage(message);
+  }
+
+  public dispose() {
+    WebviewManager.currentPanel = undefined;
+    this._panel.dispose();
+    while (this._disposables.length) {
+      this._disposables.pop()?.dispose();
+    }
+  }
+
+  private _getHtmlForWebview(extensionPath: string): string {
+    const htmlPath = path.join(extensionPath, "webview", "index.html");
+    let htmlContent = fs.readFileSync(htmlPath, "utf8");
+
+    const scriptUri = this._panel.webview.asWebviewUri(vscode.Uri.file(path.join(extensionPath, "dist", "webview.js")));
+    const styleUri = this._panel.webview.asWebviewUri(vscode.Uri.file(path.join(extensionPath, "webview", "style.css")));
+
+    htmlContent = htmlContent.replace("webview.js", scriptUri.toString());
+    htmlContent = htmlContent.replace("style.css", styleUri.toString());
+
+    return htmlContent;
+  }
+}


### PR DESCRIPTION
This commit extracts the webview panel's creation, lifecycle, and message handling into a new, dedicated `WebviewManager` class.

This change improves the separation of concerns, allowing the `SettingsPanel` class to act as a pure controller for settings logic, while the `WebviewManager` handles all view-related responsibilities.

This new architecture also resolves a race condition where the initial settings data could be sent from the `SettingsPanel` before the webview was ready to receive it.