### PR TITLE
refactor: Eliminate 'any' types for full type safety

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -6,20 +6,17 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
-import palette from "./src/palettes";
+import palette, { Palettes, Palette as PaletteType } from "./src/palettes"; // Import Palettes and Palette types
 import * as C from "./src/constants";
-
-type Palette = { [key: string]: string };
-type GenericSettings = { [key: string]: any };
-type SyntaxOverrides = { [flavor: string]: Palette };
+import { FontStyles, SyntaxOverrides } from "./src/ConfigurationService";
 
 const THEME_DIR = path.resolve(__dirname, "..", C.THEMES_DIR);
 const TEMPLATE_PATH = path.resolve(__dirname, "..", C.SRC_DIR, C.TEMPLATE_FILE);
-const FLAVORS = Object.keys(palette);
+const FLAVORS = Object.keys(palette) as Array<keyof Palettes>;
 
 export async function buildAllFlavors(
   accentIdentifier: string,
-  editorSettings: GenericSettings,
+  editorSettings: FontStyles,
   syntaxOverrides: SyntaxOverrides
 ): Promise<void> {
   await fs.emptyDir(THEME_DIR);
@@ -27,14 +24,14 @@ export async function buildAllFlavors(
   const templateStr = await fs.readFile(TEMPLATE_PATH, "utf-8");
 
   for (const flavor of FLAVORS) {
-    const basePalette = (palette as { [key: string]: any })[flavor];
+    const basePalette = palette[flavor];
     const flavorOverrides = syntaxOverrides[flavor] || {};
     const finalPalette = { ...basePalette, ...flavorOverrides };
     const accentColor = accentIdentifier.startsWith("#")
       ? accentIdentifier
       : finalPalette[accentIdentifier] || finalPalette[C.FALLBACK_ACCENT];
     const accentHexValue = accentColor.substring(1);
-    const resolvedPalette: Palette = {};
+    const resolvedPalette: { [key: string]: string } = {};
 
     for (const [key, value] of Object.entries(finalPalette)) {
       if (typeof value === "string" && value.startsWith(C.ACCENT_RECIPE_PREFIX)) {
@@ -45,7 +42,7 @@ export async function buildAllFlavors(
       }
     }
 
-    const replacements: GenericSettings = { ...resolvedPalette, accent: accentColor, ...editorSettings };
+    const replacements = { ...resolvedPalette, accent: accentColor, ...editorSettings };
     let themeContent = templateStr;
 
     for (const [key, value] of Object.entries(replacements)) {
@@ -70,7 +67,7 @@ export async function buildAllFlavors(
 /**
  * Reads the package.json to get the default font styles.
  */
-function getDefaultFontStyles() {
+function getDefaultFontStyles(): FontStyles {
   const packageJsonPath = path.resolve(__dirname, "..", "package.json");
   const packageJson = fs.readJsonSync(packageJsonPath);
   return packageJson?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.fontStyles`]?.default ?? {};

--- a/extension.ts
+++ b/extension.ts
@@ -74,7 +74,7 @@ export function activate(context: vscode.ExtensionContext) {
       const fontStyles = ConfigurationService.getFontStyles();
       const syntaxOverrides = ConfigurationService.getSyntaxOverrides();
 
-      await buildAllFlavors(accentValue, fontStyles || {}, syntaxOverrides as any);
+      await buildAllFlavors(accentValue, fontStyles, syntaxOverrides);
 
       const selection = await vscode.window.showInformationMessage(C.INFO_MESSAGE, C.RELOAD_ACTION);
 

--- a/src/ConfigurationService.ts
+++ b/src/ConfigurationService.ts
@@ -35,18 +35,18 @@ export class ConfigurationService {
 
   /**
    * Gets the user-defined font styles.
-   * @returns {{ [key: string]: string } | undefined} The font styles object.
+   * @returns {FontStyles} The font styles object.
    */
-  public static getFontStyles() {
-    return this.config.get<{ [key: string]: string }>(C.CONFIG_KEY_FONT_STYLES);
+  public static getFontStyles(): FontStyles {
+    return this.config.get<FontStyles>(C.CONFIG_KEY_FONT_STYLES, {});
   }
 
   /**
    * Gets the user-defined syntax color overrides.
-   * @returns {object} The syntax overrides object.
+   * @returns {SyntaxOverrides} The syntax overrides object.
    */
-  public static getSyntaxOverrides() {
-    return this.config.get<object>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {});
+  public static getSyntaxOverrides(): SyntaxOverrides {
+    return this.config.get<SyntaxOverrides>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {});
   }
 
   /**

--- a/src/SettingsPanel.ts
+++ b/src/SettingsPanel.ts
@@ -1,13 +1,42 @@
+/**
+ * @file This file manages the logic for the Calmppuccin Customization webview panel.
+ * It acts as a controller, handling communication between the webview UI and the extension's configuration.
+ */
+
 import * as vscode from "vscode";
 import * as C from "./constants";
-import palettes from "./palettes";
+import palettes, { Palettes } from "./palettes";
 import { WebviewManager } from "./WebviewManager";
-import { ConfigurationService, SyntaxOverrides } from "./ConfigurationService";
+import { ConfigurationService, FontStyles, SyntaxOverrides } from "./ConfigurationService";
 
-/**
- * An array of syntax keys that are customizable in the UI.
- * This acts as a single source of truth for which options to display.
- */
+// #region Webview Message Types
+/** Defines a message to update a font style setting. */
+type UpdateSettingMessage = { command: "updateSetting"; key: string; value: string };
+/** Defines a message to reset a font style setting to its default. */
+type ResetFontStyleMessage = { command: "resetFontStyle"; key: string };
+/** Defines a message to update the active accent color. */
+type UpdateAccentMessage = { command: "updateAccent"; value: string };
+/** Defines a message to update the custom accent color hex code. */
+type UpdateCustomAccentMessage = { command: "updateCustomAccent"; value: string };
+/** Defines a message to update a specific syntax color for a flavor. */
+type UpdateSyntaxColorMessage = { command: "updateSyntaxColor"; flavor: string; key: string; value: string };
+/** Defines a message to reset a specific syntax color for a flavor. */
+type ResetSyntaxColorMessage = { command: "resetSyntaxColor"; flavor: string; key: string };
+/** Defines a message to reset all extension settings to their defaults. */
+type ResetAllMessage = { command: "resetAll" };
+
+/** A discriminated union of all possible messages that can be sent from the webview to the extension. */
+type WebviewMessage =
+  | UpdateSettingMessage
+  | ResetFontStyleMessage
+  | UpdateAccentMessage
+  | UpdateCustomAccentMessage
+  | UpdateSyntaxColorMessage
+  | ResetSyntaxColorMessage
+  | ResetAllMessage;
+// #endregion
+
+/** An array of syntax keys that are customizable in the UI. */
 const customizableSyntaxKeys = [
   "comment",
   "variable",
@@ -43,6 +72,19 @@ const customizableSyntaxKeys = [
   "text",
 ];
 
+/**
+ * A type guard to check if a string is a valid flavor key from the palettes.
+ * @param key The string to check.
+ * @returns {boolean} True if the key is a valid flavor name.
+ */
+function isFlavor(key: string): key is keyof Palettes {
+  return key in palettes;
+}
+
+/**
+ * Manages the state and logic of the settings webview panel.
+ * This class follows a singleton pattern to ensure only one panel exists.
+ */
 export class SettingsPanel {
   private static _instance: SettingsPanel | undefined;
   private readonly _context: vscode.ExtensionContext;
@@ -51,103 +93,132 @@ export class SettingsPanel {
     this._context = context;
   }
 
+  /**
+   * Creates a new settings panel or reveals the existing one.
+   * @param context The extension context from VS Code.
+   */
   public static createOrShow(context: vscode.ExtensionContext) {
     if (!SettingsPanel._instance) {
       SettingsPanel._instance = new SettingsPanel(context);
     }
-
     WebviewManager.createOrShow(context, SettingsPanel._instance._handleMessage.bind(SettingsPanel._instance));
-
     SettingsPanel._instance._update();
   }
 
+  /**
+   * Sends updated settings to the webview panel if it is currently visible.
+   */
   public static updateIfVisible() {
     SettingsPanel._instance?._update();
   }
 
-  private async _handleMessage(message: any) {
+  /**
+   * Handles incoming messages from the webview panel.
+   * @param {WebviewMessage} message The deserialized message object sent from the webview.
+   */
+  private async _handleMessage(message: WebviewMessage) {
+    // The 'command' property is used as a discriminator for the message type.
+    // TypeScript correctly infers the shape of 'message' in each case block.
     switch (message.command) {
-      case C.WEBVIEW_COMMANDS.UPDATE_SETTING: {
+      case C.WEBVIEW_COMMANDS.UPDATE_SETTING:
         await ConfigurationService.updateFontStyle(message.key, message.value);
         return;
-      }
-      case C.WEBVIEW_COMMANDS.RESET_FONT_STYLE: {
+      case C.WEBVIEW_COMMANDS.RESET_FONT_STYLE:
         await ConfigurationService.resetFontStyle(message.key);
         return;
-      }
       case C.WEBVIEW_COMMANDS.UPDATE_ACCENT:
         await ConfigurationService.updateAccent(message.value);
         return;
       case C.WEBVIEW_COMMANDS.UPDATE_CUSTOM_ACCENT:
         await ConfigurationService.updateCustomAccent(message.value);
         return;
-      case C.WEBVIEW_COMMANDS.UPDATE_SYNTAX_COLOR: {
+      case C.WEBVIEW_COMMANDS.UPDATE_SYNTAX_COLOR:
         await ConfigurationService.updateSyntaxColor(message.flavor, message.key, message.value);
         return;
-      }
-      case C.WEBVIEW_COMMANDS.RESET_SYNTAX_COLOR: {
+      case C.WEBVIEW_COMMANDS.RESET_SYNTAX_COLOR:
         await ConfigurationService.resetSyntaxColor(message.flavor, message.key);
         return;
-      }
-      case C.WEBVIEW_COMMANDS.RESET_ALL: {
+      case C.WEBVIEW_COMMANDS.RESET_ALL:
         await ConfigurationService.resetAll();
         this._update();
         return;
-      }
     }
   }
 
-  private _getFlavorFromTheme(themeName: string): string {
+  /**
+   * Parses the active VS Code theme name to determine the current Calmppuccin flavor.
+   * @param {string} themeName The full name of the active color theme.
+   * @returns {keyof Palettes} The corresponding flavor key (e.g., "mocha").
+   */
+  private _getFlavorFromTheme(themeName: string): keyof Palettes {
     const calmppuccinPrefix = "calmppuccin ";
     if (themeName.toLowerCase().startsWith(calmppuccinPrefix)) {
-      return themeName
+      const flavor = themeName
         .slice(calmppuccinPrefix.length)
         .toLowerCase()
         .replace(/ /g, "-")
+        // Normalize accented characters (like 'é' in 'Frappé') to their base character 'e'
         .normalize("NFD")
         .replace(/[\u0300-\u036f]/g, "");
+
+      if (isFlavor(flavor)) {
+        return flavor;
+      }
     }
+    // Fallback to a default flavor if parsing fails.
     return "mocha";
   }
 
+  /**
+   * Gathers all current settings and posts them to the webview panel to update its state.
+   */
   private _update() {
     if (!WebviewManager.currentPanel) return;
 
-    const config = vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
+    // --- 1. Get all necessary configurations ---
     const workbenchConfig = vscode.workspace.getConfiguration("workbench");
     const extensionConfig = vscode.extensions.getExtension("kenan-salar.calmppuccin-vscode")?.packageJSON;
     const activeTheme = workbenchConfig.get<string>("colorTheme", "Calmppuccin Mocha");
+
+    // Get strongly-typed settings from our centralized service
     const activeFlavor = this._getFlavorFromTheme(activeTheme);
-    const fontStyles = ConfigurationService.getFontStyles();
-    const syntaxOverrides: SyntaxOverrides = ConfigurationService.getSyntaxOverrides() as SyntaxOverrides;
-    const currentAccent = vscode.workspace
-      .getConfiguration(C.EXTENSION_NAMESPACE)
-      .get<string>(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT);
+    const fontStyles: FontStyles = ConfigurationService.getFontStyles();
+    const syntaxOverrides: SyntaxOverrides = ConfigurationService.getSyntaxOverrides();
+    const currentAccent = ConfigurationService.getAccent(); // Handles "custom" logic internally
     const customAccentColor = vscode.workspace
       .getConfiguration(C.EXTENSION_NAMESPACE)
       .get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
+
+    // Get default values from package.json for comparison and reset functionality
     const defaultFontStyles =
       extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_FONT_STYLES}`]
         ?.default ?? {};
     const accentOptions =
       extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`]?.enum ??
       [];
-    const defaultPalette = (palettes as any)[activeFlavor];
+
+    // --- 2. Prepare data specifically for the webview ---
+    const defaultPalette = palettes[activeFlavor];
     const overridePalette = syntaxOverrides[activeFlavor] || {};
     const activeThemeBackgroundColor = defaultPalette.crust;
 
-    const accentColorPalettes = accentOptions.reduce((acc: any, option: string) => {
-      if (defaultPalette[option]) acc[option] = defaultPalette[option];
+    // Create a map of accent names to their hex codes for the current flavor
+    const accentColorPalettes = accentOptions.reduce((acc: { [key: string]: string }, option: string) => {
+      if (defaultPalette[option]) {
+        acc[option] = defaultPalette[option];
+      }
       return acc;
     }, {});
 
+    // Combine default and overridden settings into a single structure for the UI
     const syntaxSettings = customizableSyntaxKeys.map((key) => ({
       key: key,
-      fontStyle: (fontStyles as any)?.[`${key}FontStyle`] ?? "none",
+      fontStyle: fontStyles[`${key}FontStyle`] ?? "none",
       color: overridePalette[key] || defaultPalette[key],
       defaultColor: defaultPalette[key],
     }));
 
+    // --- 3. Post the complete settings payload to the webview ---
     WebviewManager.currentPanel.postMessage({
       command: C.WEBVIEW_COMMANDS.LOAD_SETTINGS,
       settings: {

--- a/src/palettes.ts
+++ b/src/palettes.ts
@@ -1,11 +1,11 @@
 // This file imports all the partial palettes and combines them into one object.
-interface Palette {
+export interface Palette {
   themeName: string;
   themeType: "light" | "dark";
   [colorName: string]: string;
 }
 
-interface Palettes {
+export interface Palettes {
   latte: Palette;
   frappe: Palette;
   macchiato: Palette;


### PR DESCRIPTION
This commit completes the migration to a fully type-safe codebase by removing all remaining `any` types from the extension's core logic.

Key changes include:
- Centralized `FontStyles` and `SyntaxOverrides` types in ConfigurationService to act as a single source of truth.
- Implemented a discriminated union (`WebviewMessage`) for the contract between the webview and the extension, ensuring all messages are strongly typed.
- Updated `build.ts`, `extension.ts`, and `SettingsPanel.ts` to consume these strong types, removing all previous `any` casts.
- Added a type guard for theme flavors to ensure safe access to palette properties.

This refactoring significantly improves robustness by enabling compile-time error checking and enhances the developer experience with better IntelliSense and code clarity.