### PR TITLE
refactor(architecture): Decouple SettingsPanel from data logic

### DIFF
--- a/src/ConfigurationService.ts
+++ b/src/ConfigurationService.ts
@@ -1,32 +1,67 @@
+/**
+ * @file This file serves as a centralized service for all interactions with the VS Code configuration API.
+ * It provides a clean, static interface for getting and setting all extension-related options,
+ * abstracting the direct `vscode.workspace.getConfiguration` calls away from other parts of the extension.
+ */
+
 import * as vscode from "vscode";
 import * as C from "./constants";
+import palettes, { Palettes } from "./palettes";
 
-// Define a type for the font styles configuration object
+// #region Exported Types
+/** Defines the shape of the font styles configuration object in settings.json. */
 export interface FontStyles {
   [key: string]: string;
 }
 
-// Define a type for the syntax overrides configuration object
+/** Defines the shape of the syntax color overrides object in settings.json. */
 export interface SyntaxOverrides {
   [flavor: string]: {
     [token: string]: string;
   };
 }
 
+/** Defines the complete data payload required by the settings webview. */
+export interface WebViewSettings {
+  activeFlavor: keyof Palettes;
+  syntaxSettings: { key: string; fontStyle: string; color: string; defaultColor: string }[];
+  currentAccent: string;
+  accentOptions: string[];
+  customAccentColor: string;
+  defaultFontStyles: { [key: string]: string };
+  activeThemeBackgroundColor: string;
+  accentColorPalettes: { [key: string]: string };
+}
+// #endregion
+
+/**
+ * A type guard to check if a string is a valid flavor key from the palettes.
+ * @param key The string to check.
+ * @returns {boolean} True if the key is a valid flavor name.
+ */
+function isFlavor(key: string): key is keyof Palettes {
+  return key in palettes;
+}
+
+/**
+ * A static utility class for managing all Calmppuccin settings in VS Code.
+ */
 export class ConfigurationService {
   /**
-   * Gets the VS Code configuration object for the Calmppuccin extension.
+   * Gets the VS Code configuration object scoped to the Calmppuccin extension.
+   * @private
    */
   private static get config() {
     return vscode.workspace.getConfiguration(C.EXTENSION_NAMESPACE);
   }
 
   /**
-   * Gets the currently configured accent color.
-   * @returns {string} The active accent color value.
+   * Gets the currently configured accent color, resolving the 'custom' option to its hex value.
+   * @returns {string} The active accent color value (e.g., "sapphire" or a hex code like "#89b4fa").
    */
   public static getAccent(): string {
     const accentSetting = this.config.get<string>(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT);
+    // If the user has selected "custom", we fetch the value from the custom accent color setting.
     if (accentSetting === "custom") {
       return this.config.get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
     }
@@ -34,45 +69,47 @@ export class ConfigurationService {
   }
 
   /**
-   * Gets the user-defined font styles.
-   * @returns {FontStyles} The font styles object.
+   * Gets the user-defined font styles from settings.json.
+   * @returns {FontStyles} The font styles object. Returns an empty object if not set.
    */
   public static getFontStyles(): FontStyles {
     return this.config.get<FontStyles>(C.CONFIG_KEY_FONT_STYLES, {});
   }
 
   /**
-   * Gets the user-defined syntax color overrides.
-   * @returns {SyntaxOverrides} The syntax overrides object.
+   * Gets the user-defined syntax color overrides from settings.json.
+   * @returns {SyntaxOverrides} The syntax overrides object. Returns an empty object if not set.
    */
   public static getSyntaxOverrides(): SyntaxOverrides {
     return this.config.get<SyntaxOverrides>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {});
   }
 
   /**
-   * Updates a specific font style setting.
+   * Updates a specific font style setting in the user's global settings.json.
    * @param {string} key The font style key to update (e.g., "commentFontStyle").
-   * @param {string} value The new font style value.
+   * @param {string} value The new font style value (e.g., "italic").
    */
   public static async updateFontStyle(key: string, value: string) {
-    const fontStyles = this.getFontStyles() || {};
+    const fontStyles = this.getFontStyles();
     await this.config.update(C.CONFIG_KEY_FONT_STYLES, { ...fontStyles, [key]: value }, vscode.ConfigurationTarget.Global);
   }
 
   /**
-   * Resets a specific font style to its default by removing it from the settings.
+   * Resets a specific font style to its default by removing it from the user's settings.json.
    * @param {string} key The font style key to reset.
    */
   public static async resetFontStyle(key: string) {
     const fontStyles: FontStyles = { ...this.getFontStyles() };
     delete fontStyles[key];
+    // If the fontStyles object is empty after deletion, set it to 'undefined'.
+    // This completely removes the "calmppuccin.fontStyles" entry from settings.json.
     const finalFontStyles = Object.keys(fontStyles).length === 0 ? undefined : fontStyles;
     await this.config.update(C.CONFIG_KEY_FONT_STYLES, finalFontStyles, vscode.ConfigurationTarget.Global);
   }
 
   /**
    * Updates the accent color setting.
-   * @param {string} value The new accent color name.
+   * @param {string} value The new accent color name (e.g., "mauve").
    */
   public static async updateAccent(value: string) {
     await this.config.update(C.CONFIG_KEY_ACCENT, value, vscode.ConfigurationTarget.Global);
@@ -80,19 +117,21 @@ export class ConfigurationService {
 
   /**
    * Updates the custom accent color hex code.
-   * @param {string} value The new hex color value.
+   * @param {string} value The new hex color value (e.g., "#89b4fa").
    */
   public static async updateCustomAccent(value: string) {
     await this.config.update(C.CONFIG_KEY_CUSTOM_ACCENT, value, vscode.ConfigurationTarget.Global);
   }
 
   /**
-   * Updates a specific syntax color override.
+   * Updates a specific syntax color override for a given flavor.
    * @param {string} flavor The theme flavor (e.g., "mocha").
    * @param {string} key The syntax key (e.g., "comment").
    * @param {string} value The new hex color value.
    */
   public static async updateSyntaxColor(flavor: string, key: string, value: string) {
+    // We deep-clone the settings object because the object returned by .get() is read-only.
+    // This creates a mutable copy that we can safely modify before updating the configuration.
     const overrides: SyntaxOverrides = JSON.parse(JSON.stringify(this.getSyntaxOverrides()));
     if (!overrides[flavor]) {
       overrides[flavor] = {};
@@ -102,7 +141,7 @@ export class ConfigurationService {
   }
 
   /**
-   * Resets a specific syntax color override.
+   * Resets a specific syntax color override for a given flavor.
    * @param {string} flavor The theme flavor.
    * @param {string} key The syntax key.
    */
@@ -110,20 +149,133 @@ export class ConfigurationService {
     const overrides: SyntaxOverrides = JSON.parse(JSON.stringify(this.getSyntaxOverrides()));
     if (overrides[flavor]?.[key]) {
       delete overrides[flavor][key];
+      // If a flavor object becomes empty, remove it entirely.
       if (Object.keys(overrides[flavor]).length === 0) {
         delete overrides[flavor];
       }
+      // If the top-level overrides object is now empty, remove the entire setting.
       const finalOverrides = Object.keys(overrides).length === 0 ? undefined : overrides;
       await this.config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, finalOverrides, vscode.ConfigurationTarget.Global);
     }
   }
 
   /**
-   * Resets all user-defined settings for the extension to their defaults.
+   * Resets all user-defined settings for the extension to their default values.
    */
   public static async resetAll() {
     await this.config.update(C.CONFIG_KEY_FONT_STYLES, undefined, vscode.ConfigurationTarget.Global);
     await this.config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, undefined, vscode.ConfigurationTarget.Global);
     await this.config.update(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT, vscode.ConfigurationTarget.Global);
+  }
+
+  /**
+   * Parses the active VS Code theme name to determine the current Calmppuccin flavor.
+   * @returns {keyof Palettes} The corresponding flavor key (e.g., "mocha").
+   * @private
+   */
+  private static getActiveFlavor(): keyof Palettes {
+    const workbenchConfig = vscode.workspace.getConfiguration("workbench");
+    const themeName = workbenchConfig.get<string>("colorTheme", "");
+    const calmppuccinPrefix = "calmppuccin ";
+
+    if (themeName.toLowerCase().startsWith(calmppuccinPrefix)) {
+      const flavor = themeName
+        .slice(calmppuccinPrefix.length)
+        .toLowerCase()
+        .replace(/ /g, "-")
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "");
+
+      if (isFlavor(flavor)) {
+        return flavor;
+      }
+    }
+    return "mocha"; // Default fallback
+  }
+
+  /**
+   * Gathers all settings required by the webview into a single object.
+   * @returns {WebViewSettings} The complete settings payload for the webview.
+   */
+  public static getWebViewSettings(): WebViewSettings {
+    const extensionConfig = vscode.extensions.getExtension("kenan-salar.calmppuccin-vscode")?.packageJSON;
+    const customizableSyntaxKeys = [
+      "comment",
+      "variable",
+      "keyword",
+      "type",
+      "namespace",
+      "namespaceAttribute",
+      "module",
+      "annotation",
+      "directive",
+      "decorator",
+      "class",
+      "interface",
+      "struct",
+      "enum",
+      "enumMember",
+      "fieldAndAttribute",
+      "property",
+      "propertyReadOnly",
+      "functionAndMethod",
+      "extensionMethod",
+      "delegate",
+      "event",
+      "parameter",
+      "typeParameter",
+      "number",
+      "constant",
+      "operator",
+      "operatorOverload",
+      "punctuation",
+      "string",
+      "stringVerbatim",
+      "text",
+    ];
+
+    // Get strongly-typed settings using existing methods
+    const activeFlavor = this.getActiveFlavor();
+    const fontStyles = this.getFontStyles();
+    const syntaxOverrides = this.getSyntaxOverrides();
+    const currentAccent = this.getAccent();
+    const customAccentColor = this.config.get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
+
+    // Get default values from package.json
+    const defaultFontStyles =
+      extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_FONT_STYLES}`]
+        ?.default ?? {};
+    const accentOptions =
+      extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`]?.enum ??
+      [];
+
+    const defaultPalette = palettes[activeFlavor];
+    const overridePalette = syntaxOverrides[activeFlavor] || {};
+    const activeThemeBackgroundColor = defaultPalette.crust;
+
+    const accentColorPalettes = accentOptions.reduce((acc: { [key: string]: string }, option: string) => {
+      if (defaultPalette[option]) {
+        acc[option] = defaultPalette[option];
+      }
+      return acc;
+    }, {});
+
+    const syntaxSettings = customizableSyntaxKeys.map((key) => ({
+      key: key,
+      fontStyle: fontStyles[`${key}FontStyle`] ?? "none",
+      color: overridePalette[key] || defaultPalette[key],
+      defaultColor: defaultPalette[key],
+    }));
+
+    return {
+      activeFlavor,
+      syntaxSettings,
+      currentAccent,
+      accentOptions,
+      customAccentColor,
+      defaultFontStyles,
+      activeThemeBackgroundColor,
+      accentColorPalettes,
+    };
   }
 }

--- a/src/SettingsPanel.ts
+++ b/src/SettingsPanel.ts
@@ -5,9 +5,8 @@
 
 import * as vscode from "vscode";
 import * as C from "./constants";
-import palettes, { Palettes } from "./palettes";
 import { WebviewManager } from "./WebviewManager";
-import { ConfigurationService, FontStyles, SyntaxOverrides } from "./ConfigurationService";
+import { ConfigurationService } from "./ConfigurationService";
 
 // #region Webview Message Types
 /** Defines a message to update a font style setting. */
@@ -36,51 +35,6 @@ type WebviewMessage =
   | ResetAllMessage;
 // #endregion
 
-/** An array of syntax keys that are customizable in the UI. */
-const customizableSyntaxKeys = [
-  "comment",
-  "variable",
-  "keyword",
-  "type",
-  "namespace",
-  "namespaceAttribute",
-  "module",
-  "annotation",
-  "directive",
-  "decorator",
-  "class",
-  "interface",
-  "struct",
-  "enum",
-  "enumMember",
-  "fieldAndAttribute",
-  "property",
-  "propertyReadOnly",
-  "functionAndMethod",
-  "extensionMethod",
-  "delegate",
-  "event",
-  "parameter",
-  "typeParameter",
-  "number",
-  "constant",
-  "operator",
-  "operatorOverload",
-  "punctuation",
-  "string",
-  "stringVerbatim",
-  "text",
-];
-
-/**
- * A type guard to check if a string is a valid flavor key from the palettes.
- * @param key The string to check.
- * @returns {boolean} True if the key is a valid flavor name.
- */
-function isFlavor(key: string): key is keyof Palettes {
-  return key in palettes;
-}
-
 /**
  * Manages the state and logic of the settings webview panel.
  * This class follows a singleton pattern to ensure only one panel exists.
@@ -95,7 +49,7 @@ export class SettingsPanel {
 
   /**
    * Creates a new settings panel or reveals the existing one.
-   * @param context The extension context from VS Code.
+   * @param {vscode.ExtensionContext} context The extension context from VS Code.
    */
   public static createOrShow(context: vscode.ExtensionContext) {
     if (!SettingsPanel._instance) {
@@ -146,91 +100,17 @@ export class SettingsPanel {
   }
 
   /**
-   * Parses the active VS Code theme name to determine the current Calmppuccin flavor.
-   * @param {string} themeName The full name of the active color theme.
-   * @returns {keyof Palettes} The corresponding flavor key (e.g., "mocha").
-   */
-  private _getFlavorFromTheme(themeName: string): keyof Palettes {
-    const calmppuccinPrefix = "calmppuccin ";
-    if (themeName.toLowerCase().startsWith(calmppuccinPrefix)) {
-      const flavor = themeName
-        .slice(calmppuccinPrefix.length)
-        .toLowerCase()
-        .replace(/ /g, "-")
-        // Normalize accented characters (like 'é' in 'Frappé') to their base character 'e'
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "");
-
-      if (isFlavor(flavor)) {
-        return flavor;
-      }
-    }
-    // Fallback to a default flavor if parsing fails.
-    return "mocha";
-  }
-
-  /**
-   * Gathers all current settings and posts them to the webview panel to update its state.
+   * Gathers all current settings via the ConfigurationService and posts them to the webview.
    */
   private _update() {
     if (!WebviewManager.currentPanel) return;
 
-    // --- 1. Get all necessary configurations ---
-    const workbenchConfig = vscode.workspace.getConfiguration("workbench");
-    const extensionConfig = vscode.extensions.getExtension("kenan-salar.calmppuccin-vscode")?.packageJSON;
-    const activeTheme = workbenchConfig.get<string>("colorTheme", "Calmppuccin Mocha");
+    // The ONLY responsibility of this method now is to get the complete settings payload and post it.
+    const settings = ConfigurationService.getWebViewSettings();
 
-    // Get strongly-typed settings from our centralized service
-    const activeFlavor = this._getFlavorFromTheme(activeTheme);
-    const fontStyles: FontStyles = ConfigurationService.getFontStyles();
-    const syntaxOverrides: SyntaxOverrides = ConfigurationService.getSyntaxOverrides();
-    const currentAccent = ConfigurationService.getAccent(); // Handles "custom" logic internally
-    const customAccentColor = vscode.workspace
-      .getConfiguration(C.EXTENSION_NAMESPACE)
-      .get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
-
-    // Get default values from package.json for comparison and reset functionality
-    const defaultFontStyles =
-      extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_FONT_STYLES}`]
-        ?.default ?? {};
-    const accentOptions =
-      extensionConfig?.contributes?.configuration?.properties?.[`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`]?.enum ??
-      [];
-
-    // --- 2. Prepare data specifically for the webview ---
-    const defaultPalette = palettes[activeFlavor];
-    const overridePalette = syntaxOverrides[activeFlavor] || {};
-    const activeThemeBackgroundColor = defaultPalette.crust;
-
-    // Create a map of accent names to their hex codes for the current flavor
-    const accentColorPalettes = accentOptions.reduce((acc: { [key: string]: string }, option: string) => {
-      if (defaultPalette[option]) {
-        acc[option] = defaultPalette[option];
-      }
-      return acc;
-    }, {});
-
-    // Combine default and overridden settings into a single structure for the UI
-    const syntaxSettings = customizableSyntaxKeys.map((key) => ({
-      key: key,
-      fontStyle: fontStyles[`${key}FontStyle`] ?? "none",
-      color: overridePalette[key] || defaultPalette[key],
-      defaultColor: defaultPalette[key],
-    }));
-
-    // --- 3. Post the complete settings payload to the webview ---
     WebviewManager.currentPanel.postMessage({
       command: C.WEBVIEW_COMMANDS.LOAD_SETTINGS,
-      settings: {
-        activeFlavor,
-        syntaxSettings,
-        currentAccent,
-        accentOptions,
-        customAccentColor,
-        defaultFontStyles,
-        activeThemeBackgroundColor,
-        accentColorPalettes,
-      },
+      settings: settings,
     });
   }
 }


### PR DESCRIPTION
Centralizes all data-gathering responsibilities within the ConfigurationService by introducing a new `getWebViewSettings` method.

Previously, the SettingsPanel was tightly coupled to various VS Code APIs and other services to assemble the data payload for the webview.

This commit moves all of that logic into the ConfigurationService, making it the single source of truth for settings data. The SettingsPanel is now a much simpler controller, responsible only for orchestrating communication between the webview and the service.

This improves separation of concerns, enhances testability, and makes the overall architecture cleaner and more maintainable.