### PR TITLE
feat(customization): add dynamic views for syntax, brackets, and json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 - **Feature**: Added `.dockerignore` file
 - **Feature**: The hex code input fields for syntax colors in the Customization UI are now fully interactive. Users can type or paste a hex code, including an 8-digit code with transparency, and the color picker, alpha slider, and live preview will update in real-time.
+- **Feature**: The Customization UI now features a view selector to switch between "Syntax", "Brackets", and "JSON" settings. This organizes the panel and provides dedicated live previews for each category.
 - **Feature**: Added unit tests for the webview.
 - **Improvement**: Cached github workflow for the npm dependencies and docker image so that the pipline is significant faster.
 - **Fix**: Updated the extension's configuration schema (package.json). VS Code will now correctly validate 8-digit hex codes with alpha channels when a user edits their settings.json manually.
+- **Fix**: Corrected a CSS grid layout issue that caused the bracket color settings to be displayed in a disorganized manner.
+- **Fix**: Updated the webview unit tests to align with the new data structures, resolving a test failure caused by the recent feature addition.
 
 ## [1.6.2] - 2025-08-25
 

--- a/package.json
+++ b/package.json
@@ -184,7 +184,16 @@
             "punctuationFontStyle": "none",
             "stringFontStyle": "none",
             "stringVerbatimFontStyle": "italic",
-            "textFontStyle": "none"
+            "textFontStyle": "none",
+            "jsonLvl0FontStyle": "none",
+            "jsonLvl1FontStyle": "none",
+            "jsonLvl2FontStyle": "none",
+            "jsonLvl3FontStyle": "none",
+            "jsonLvl4FontStyle": "none",
+            "jsonLvl5FontStyle": "none",
+            "jsonLvl6FontStyle": "none",
+            "jsonLvl7FontStyle": "none",
+            "jsonLvl8FontStyle": "none"
           },
           "properties": {
             "commentFontStyle": {
@@ -606,6 +615,114 @@
                 "italic bold",
                 "underline"
               ]
+            },
+            "jsonLvl0FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 0.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl1FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 1.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl2FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 2.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl3FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 3.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl4FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 4.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl5FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 5.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl6FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 6.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl7FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 7.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
+            },
+            "jsonLvl8FontStyle": {
+              "type": "string",
+              "default": "none",
+              "description": "Set the font style for json lvl 8.",
+              "enum": [
+                "none",
+                "italic",
+                "bold",
+                "italic bold",
+                "underline"
+              ]
             }
           }
         },
@@ -820,6 +937,96 @@
                   "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
                   "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
                   "description": "Overrides the color for plain text."
+                },
+                "uiBracket1": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the first bracket pair."
+                },
+                "uiBracket2": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the second bracket pair."
+                },
+                "uiBracket3": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the third bracket pair."
+                },
+                "uiBracket4": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the fourth bracket pair."
+                },
+                "uiBracket5": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the fifth bracket pair."
+                },
+                "uiBracket6": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the sixth bracket pair."
+                },
+                "jsonLvl0": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the top-level JSON keys."
+                },
+                "jsonLvl1": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the second-level JSON keys."
+                },
+                "jsonLvl2": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the third-level JSON keys."
+                },
+                "jsonLvl3": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the fourth-level JSON keys."
+                },
+                "jsonLvl4": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the fifth-level JSON keys."
+                },
+                "jsonLvl5": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the sixth-level JSON keys."
+                },
+                "jsonLvl6": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the seventh-level JSON keys."
+                },
+                "jsonLvl7": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the eighth-level JSON keys."
+                },
+                "jsonLvl8": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
+                  "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
+                  "description": "Overrides the color for the ninth-level JSON keys."
                 }
               }
             }

--- a/src/ConfigurationService.ts
+++ b/src/ConfigurationService.ts
@@ -21,10 +21,20 @@ export interface SyntaxOverrides {
   };
 }
 
+/** Defines a single setting item for the webview. */
+export interface WebviewSetting {
+  key: string;
+  fontStyle?: string;
+  color?: string;
+  defaultColor: string;
+}
+
 /** Defines the complete data payload required by the settings webview. */
 export interface WebViewSettings {
   activeFlavor: keyof Palettes;
-  syntaxSettings: { key: string; fontStyle: string; color: string; defaultColor: string }[];
+  syntaxSettings: WebviewSetting[];
+  bracketSettings: WebviewSetting[];
+  jsonSettings: WebviewSetting[];
   currentAccent: string;
   accentOptions: string[];
   customAccentColor: string;
@@ -246,6 +256,18 @@ export class ConfigurationService {
       "stringVerbatim",
       "text",
     ];
+    const customizableBracketKeys = ["uiBracket1", "uiBracket2", "uiBracket3", "uiBracket4", "uiBracket5", "uiBracket6"];
+    const customizableJsonKeys = [
+      "jsonLvl0",
+      "jsonLvl1",
+      "jsonLvl2",
+      "jsonLvl3",
+      "jsonLvl4",
+      "jsonLvl5",
+      "jsonLvl6",
+      "jsonLvl7",
+      "jsonLvl8",
+    ];
 
     const activeFlavor = this.getActiveFlavor();
     const fontStyles = this.getFontStyles();
@@ -278,9 +300,24 @@ export class ConfigurationService {
       defaultColor: defaultPalette[key],
     }));
 
+    const bracketSettings = customizableBracketKeys.map((key) => ({
+      key: key,
+      color: overridePalette[key] || defaultPalette[key],
+      defaultColor: defaultPalette[key],
+    }));
+
+    const jsonSettings = customizableJsonKeys.map((key) => ({
+      key: key,
+      fontStyle: fontStyles[`${key}FontStyle`] ?? "none",
+      color: overridePalette[key] || defaultPalette[key],
+      defaultColor: defaultPalette[key],
+    }));
+
     return {
       activeFlavor,
       syntaxSettings,
+      bracketSettings,
+      jsonSettings,
       currentAccent,
       accentOptions,
       customAccentColor,

--- a/src/template.json
+++ b/src/template.json
@@ -1724,7 +1724,8 @@
       "name": "JSON Key - Level 0",
       "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
-        "foreground": "{{jsonLvl0}}"
+        "foreground": "{{jsonLvl0}}",
+        "fontStyle": "{{jsonLvl0FontStyle}}"
       }
     },
     {
@@ -1733,7 +1734,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl1}}"
+        "foreground": "{{jsonLvl1}}",
+        "fontStyle": "{{jsonLvl1FontStyle}}"
       }
     },
     {
@@ -1742,7 +1744,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl2}}"
+        "foreground": "{{jsonLvl2}}",
+        "fontStyle": "{{jsonLvl2FontStyle}}"
       }
     },
     {
@@ -1751,7 +1754,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl3}}"
+        "foreground": "{{jsonLvl3}}",
+        "fontStyle": "{{jsonLvl3FontStyle}}"
       }
     },
     {
@@ -1760,7 +1764,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl4}}"
+        "foreground": "{{jsonLvl4}}",
+        "fontStyle": "{{jsonLvl4FontStyle}}"
       }
     },
     {
@@ -1769,7 +1774,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl5}}"
+        "foreground": "{{jsonLvl5}}",
+        "fontStyle": "{{jsonLvl5FontStyle}}"
       }
     },
     {
@@ -1778,7 +1784,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl6}}"
+        "foreground": "{{jsonLvl6}}",
+        "fontStyle": "{{jsonLvl6FontStyle}}"
       }
     },
     {
@@ -1787,7 +1794,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl7}}"
+        "foreground": "{{jsonLvl7}}",
+        "fontStyle": "{{jsonLvl7FontStyle}}"
       }
     },
     {
@@ -1796,7 +1804,8 @@
         "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
       ],
       "settings": {
-        "foreground": "{{jsonLvl8}}"
+        "foreground": "{{jsonLvl8}}",
+        "fontStyle": "{{jsonLvl8FontStyle}}"
       }
     },
     {

--- a/test/unit/webview.test.ts
+++ b/test/unit/webview.test.ts
@@ -21,6 +21,11 @@ const htmlFixture = `
     <input type="color" id="custom-accent-picker" />
     <input type="text" id="custom-accent-hex-input" />
   </div>
+  <select id="settings-view-select">
+    <option value="syntax">Syntax</option>
+    <option value="brackets">Brackets</option>
+    <option value="json">JSON</option>
+  </select>
   <div id="settings-container"></div>
   <div id="reset-all-container"></div>
   <div class="preview-container">
@@ -42,16 +47,15 @@ const mockSettingsPayload = {
     { key: "comment", fontStyle: "italic", color: "#858aa0", defaultColor: "#858aa0" },
     { key: "keyword", fontStyle: "none", color: "#B2AADD", defaultColor: "#B2AADD" },
   ],
+  bracketSettings: [{ key: "uiBracket1", color: "#6cb3c0", defaultColor: "#6cb3c0" }],
+  jsonSettings: [{ key: "jsonLvl0", fontStyle: "none", color: "#8eb4f0", defaultColor: "#8eb4f0" }],
   currentAccent: "sapphire",
   accentOptions: ["sapphire", "mauve", "custom"],
   customAccentColor: "#89b4fa",
   activeThemeBackgroundColor: "#1d1d2c",
   accentColorPalettes: { sapphire: "#70b7d8", mauve: "#ba9ae2" },
-  defaultFontStyles: { commentFontStyle: "italic", keywordFontStyle: "none" },
+  defaultFontStyles: { commentFontStyle: "italic", keywordFontStyle: "none", jsonLvl0FontStyle: "none" },
 };
-
-// Add a helper function to normalize whitespace for robust string comparison
-const normalize = (str: string) => str.replace(/\s+/g, " ").trim();
 
 describe("UIManager Unit Tests", () => {
   let uiManager: UIManager;
@@ -70,7 +74,8 @@ describe("UIManager Unit Tests", () => {
 
     // Assert
     const languageSelect = document.getElementById("language-select") as HTMLSelectElement;
-    const expectedOptions = Object.keys(codeSnippets).length;
+    // We filter out brackets and json from the main language selector
+    const expectedOptions = Object.keys(codeSnippets).length - 2;
     expect(languageSelect.options.length).toBe(expectedOptions);
     expect(languageSelect.value).toBe("csharp");
 
@@ -105,6 +110,7 @@ describe("UIManager Unit Tests", () => {
     expect(flavorTitle?.textContent).toBe("Editing: Mocha");
 
     const settingsContainer = document.getElementById("settings-container");
+    // Should render the 'syntax' view by default
     const expectedChildren = mockSettingsPayload.syntaxSettings.length * 3;
     expect(settingsContainer?.children.length).toBe(expectedChildren);
 

--- a/webview/index.html
+++ b/webview/index.html
@@ -33,6 +33,13 @@
         <section class="card">
           <div class="card-header">
             <h3>Font Styles & Syntax Colors</h3>
+            <div class="language-selector-container">
+              <select id="settings-view-select">
+                <option value="syntax">Syntax</option>
+                <option value="brackets">Brackets</option>
+                <option value="json">JSON</option>
+              </select>
+            </div>
           </div>
           <div class="card-body" id="settings-container"></div>
         </section>

--- a/webview/main.ts
+++ b/webview/main.ts
@@ -9,10 +9,20 @@ import { codeSnippets } from "./snippets";
 // These types are duplicated from the extension's backend to create a strict, type-safe contract
 // for communication between the webview (frontend) and the extension host (backend).
 
+/** A single setting item for the webview. */
+type WebviewSetting = {
+  key: string;
+  fontStyle?: string;
+  color?: string;
+  defaultColor: string;
+};
+
 /** The message payload received from the extension when settings are loaded. */
 type SettingsPayload = {
   activeFlavor: string;
-  syntaxSettings: { key: string; fontStyle: string; color: string; defaultColor: string }[];
+  syntaxSettings: WebviewSetting[];
+  bracketSettings: WebviewSetting[];
+  jsonSettings: WebviewSetting[];
   currentAccent: string;
   accentOptions: string[];
   customAccentColor: string;
@@ -86,11 +96,14 @@ export class UIManager {
     codePreview: document.getElementById("code-preview")!,
     resetAllContainer: document.getElementById("reset-all-container")!,
     languageSelect: document.getElementById("language-select") as HTMLSelectElement,
+    settingsViewSelect: document.getElementById("settings-view-select") as HTMLSelectElement,
     dialogOverlay: document.getElementById("reset-dialog-overlay")!,
     confirmResetButton: document.getElementById("dialog-confirm-button")!,
     cancelResetButton: document.getElementById("dialog-cancel-button")!,
   };
 
+  /** Holds the current settings payload from the extension. */
+  private settings: SettingsPayload | null = null;
   /** Holds the current styling state (color and font style) for the live preview pane. */
   private previewState: { [key: string]: { color?: string; fontStyle?: string } } = {};
   /** Caches the accent color palette for the active theme flavor. */
@@ -107,9 +120,9 @@ export class UIManager {
    * @param {SettingsPayload} settings The settings object from the VS Code extension host.
    */
   public populateAllSettings(settings: SettingsPayload) {
+    this.settings = settings;
     const {
       activeFlavor,
-      syntaxSettings,
       currentAccent,
       accentOptions,
       customAccentColor,
@@ -124,7 +137,6 @@ export class UIManager {
 
     // 2. Clear previous UI elements to ensure a clean slate on theme change.
     this.elements.accentContainer.innerHTML = "";
-    this.elements.settingsContainer.innerHTML = "";
     this.elements.resetAllContainer.innerHTML = "";
 
     // 3. Set flavor-specific UI elements.
@@ -135,11 +147,10 @@ export class UIManager {
 
     // 4. Build each section of the UI dynamically.
     this._createAccentColorControls(currentAccent, accentOptions, customAccentColor);
-    this._createSyntaxControls(syntaxSettings, settings.defaultFontStyles);
     this._createResetAllButton();
+    this._handleViewChange(); // This will now render the correct initial view based on the dropdown
 
     // 5. Apply the initial state to the UI.
-    this.updatePreviewPane();
     this._handleAccentChange(currentAccent);
   }
 
@@ -150,10 +161,12 @@ export class UIManager {
   public initializeEventListeners() {
     // Populate the language selector dropdown and set up its change event.
     for (const lang in codeSnippets) {
-      const option = document.createElement("option");
-      option.value = lang;
-      option.textContent = lang;
-      this.elements.languageSelect.appendChild(option);
+      if (lang !== "brackets" && lang !== "json") {
+        const option = document.createElement("option");
+        option.value = lang;
+        option.textContent = lang;
+        this.elements.languageSelect.appendChild(option);
+      }
     }
     this.elements.languageSelect.value = "csharp";
     this.elements.codePreview.innerHTML = codeSnippets.csharp;
@@ -161,6 +174,11 @@ export class UIManager {
       const selectedLanguage = (e.target as HTMLSelectElement).value as keyof typeof codeSnippets;
       this.elements.codePreview.innerHTML = codeSnippets[selectedLanguage];
       this.updatePreviewPane();
+    });
+
+    // Listen for changes on the settings view dropdown.
+    this.elements.settingsViewSelect.addEventListener("change", () => {
+      this._handleViewChange();
     });
 
     // Listen for changes on the custom accent color pickers.
@@ -242,6 +260,27 @@ export class UIManager {
   }
 
   /**
+   * Handles the logic for showing/hiding the custom accent picker and updating the UI's accent color.
+   * @param {string} accentValue The newly selected accent value.
+   * @private
+   */
+  private _handleAccentChange(accentValue: string) {
+    const isCustom = accentValue === "custom";
+    this.elements.customAccentPickerContainer.style.display = isCustom ? "grid" : "none";
+    const newColor = isCustom ? this.elements.customAccentPicker.value : this.accentColorMap[accentValue];
+    this.updateAccentColor(newColor);
+  }
+
+  /**
+   * Updates the `--dynamic-accent-color` CSS variable to change the UI's theme in real-time.
+   * @param {string} newColor The new hex color to apply.
+   * @private
+   */
+  private updateAccentColor(newColor: string) {
+    document.documentElement.style.setProperty("--dynamic-accent-color", newColor);
+  }
+
+  /**
    * Dynamically creates the Accent Color dropdown and the custom color picker controls.
    * @private
    */
@@ -284,17 +323,60 @@ export class UIManager {
   }
 
   /**
+   * Handles the change of the settings view dropdown, rebuilding the settings grid and updating the preview.
+   * @private
+   */
+  private _handleViewChange() {
+    if (!this.settings) return;
+    const { defaultFontStyles } = this.settings;
+    const selectedView = this.elements.settingsViewSelect.value;
+
+    // Clear the container and reset its classes to the default
+    this.elements.settingsContainer.innerHTML = "";
+    this.elements.settingsContainer.className = "card-body";
+    (document.getElementById("settings-container") as HTMLElement).id = "settings-container"; // Ensure base ID is present
+
+    switch (selectedView) {
+      case "syntax":
+        // Uses the default 3-column layout, no extra class needed.
+        this._createSyntaxControls(this.settings.syntaxSettings, defaultFontStyles, true);
+        this.elements.languageSelect.style.display = ""; // Show language selector
+        this.elements.languageSelect.value = "csharp";
+        this.elements.codePreview.innerHTML = codeSnippets.csharp;
+        break;
+      case "brackets":
+        // Add a class to switch to a 2-column layout.
+        this.elements.settingsContainer.classList.add("view-brackets");
+        // Create controls without font styles.
+        this._createSyntaxControls(this.settings.bracketSettings, {}, false);
+        this.elements.languageSelect.style.display = "none"; // Hide language selector
+        this.elements.codePreview.innerHTML = codeSnippets.brackets;
+        break;
+      case "json":
+        // Uses the default 3-column layout.
+        this._createSyntaxControls(this.settings.jsonSettings, defaultFontStyles, true);
+        this.elements.languageSelect.style.display = "none"; // Hide language selector
+        this.elements.codePreview.innerHTML = codeSnippets.json;
+        break;
+    }
+    // Update the preview pane after changing the view and its content
+    this.updatePreviewPane();
+  }
+
+  /**
    * Dynamically creates the grid of controls for font styles and syntax colors.
-   * @param {SettingsPayload["syntaxSettings"]} syntaxSettings An array of the syntax settings to build controls for.
-   * @param {SettingsPayload["defaultFontStyles"]} defaultFontStyles An object containing the default font styles.
+   * @param {WebviewSetting[]} settings An array of the syntax settings to build controls for.
+   * @param {{ [key: string]: string }} defaultFontStyles An object containing the default font styles.
+   * @param {boolean} includeFontStyles Whether to include font style controls.
    * @private
    */
   private _createSyntaxControls(
-    syntaxSettings: SettingsPayload["syntaxSettings"],
-    defaultFontStyles: SettingsPayload["defaultFontStyles"]
+    settings: WebviewSetting[],
+    defaultFontStyles: { [key: string]: string },
+    includeFontStyles: boolean
   ) {
     // Loop through each customizable syntax item (e.g., comment, keyword, etc.).
-    syntaxSettings.forEach((setting) => {
+    settings.forEach((setting) => {
       const { key, fontStyle, color, defaultColor } = setting;
       const fontStyleKey = `${key}FontStyle`;
       const defaultFontStyle = defaultFontStyles[fontStyleKey] || "none";
@@ -307,13 +389,18 @@ export class UIManager {
       label.textContent = key.replace(/([A-Z])/g, " $1").trim() + ":";
       label.htmlFor = key;
 
-      // Create the individual UI controls for font style and color.
-      const fontContainer = this._createFontStyleControl(key, fontStyle, defaultFontStyle, fontStyleKey);
-      const colorContainer = this._createColorPickerControl(key, color, defaultColor);
+      let fontContainer: HTMLElement | null = null;
+      if (includeFontStyles && fontStyle !== undefined) {
+        fontContainer = this._createFontStyleControl(key, fontStyle, defaultFontStyle, fontStyleKey);
+      }
+
+      const colorContainer = this._createColorPickerControl(key, color || "", defaultColor);
 
       // Add the new elements to the settings grid in the DOM.
       this.elements.settingsContainer.appendChild(label);
-      this.elements.settingsContainer.appendChild(fontContainer);
+      if (fontContainer) {
+        this.elements.settingsContainer.appendChild(fontContainer);
+      }
       this.elements.settingsContainer.appendChild(colorContainer);
     });
   }
@@ -501,27 +588,6 @@ export class UIManager {
       this.elements.dialogOverlay.classList.remove("hidden");
     });
     this.elements.resetAllContainer.appendChild(resetAllButton);
-  }
-
-  /**
-   * Handles the logic for showing/hiding the custom accent picker and updating the UI's accent color.
-   * @param {string} accentValue The newly selected accent value.
-   * @private
-   */
-  private _handleAccentChange(accentValue: string) {
-    const isCustom = accentValue === "custom";
-    this.elements.customAccentPickerContainer.style.display = isCustom ? "grid" : "none";
-    const newColor = isCustom ? this.elements.customAccentPicker.value : this.accentColorMap[accentValue];
-    this.updateAccentColor(newColor);
-  }
-
-  /**
-   * Updates the `--dynamic-accent-color` CSS variable to change the UI's theme in real-time.
-   * @param {string} newColor The new hex color to apply.
-   * @private
-   */
-  private updateAccentColor(newColor: string) {
-    document.documentElement.style.setProperty("--dynamic-accent-color", newColor);
   }
 }
 

--- a/webview/snippets.ts
+++ b/webview/snippets.ts
@@ -19,6 +19,8 @@ import { rustSnippet } from "./snippets/rust";
 import { shellSnippet } from "./snippets/shell";
 import { sqlSnippet } from "./snippets/sql";
 import { typescriptSnippet } from "./snippets/typescript";
+import { bracketsSnippet } from "./snippets/brackets";
+import { jsonSnippet } from "./snippets/json";
 
 /**
  * Defines the shape for the code snippets object.
@@ -49,4 +51,6 @@ export const codeSnippets: CodeSnippets = {
   shell: shellSnippet,
   sql: sqlSnippet,
   typescript: typescriptSnippet,
+  brackets: bracketsSnippet,
+  json: jsonSnippet,
 };

--- a/webview/snippets/brackets.ts
+++ b/webview/snippets/brackets.ts
@@ -1,0 +1,40 @@
+export const bracketsSnippet = `
+<span data-token="comment">&lt;!-- Curly Brackets --&gt;</span>
+<span data-token="text">level 1 </span><span data-token="uiBracket1">{</span>
+  <span data-token="text">  level 2 </span><span data-token="uiBracket2">{</span>
+    <span data-token="text">    level 3 </span><span data-token="uiBracket3">{</span>
+      <span data-token="text">      level 4 </span><span data-token="uiBracket4">{</span>
+        <span data-token="text">        level 5 </span><span data-token="uiBracket5">{</span>
+          <span data-token="text">          level 6 </span><span data-token="uiBracket6">{</span><span data-token="text"> ... </span><span data-token="uiBracket6">}</span>
+        <span data-token="uiBracket5">}</span>
+      <span data-token="uiBracket4">}</span>
+    <span data-token="uiBracket3">}</span>
+  <span data-token="uiBracket2">}</span>
+<span data-token="uiBracket1">}</span>
+
+<span data-token="comment">&lt;!-- Round Brackets --&gt;</span>
+<span data-token="text">level 1 </span><span data-token="uiBracket1">(</span>
+  <span data-token="text">  level 2 </span><span data-token="uiBracket2">(</span>
+    <span data-token="text">    level 3 </span><span data-token="uiBracket3">(</span>
+      <span data-token="text">      level 4 </span><span data-token="uiBracket4">(</span>
+        <span data-token="text">        level 5 </span><span data-token="uiBracket5">(</span>
+          <span data-token="text">          level 6 </span><span data-token="uiBracket6">(</span><span data-token="text"> ... </span><span data-token="uiBracket6">)</span>
+        <span data-token="uiBracket5">)</span>
+      <span data-token="uiBracket4">)</span>
+    <span data-token="uiBracket3">)</span>
+  <span data-token="uiBracket2">)</span>
+<span data-token="uiBracket1">)</span>
+
+<span data-token="comment">&lt;!-- Square Brackets --&gt;</span>
+<span data-token="text">level 1 </span><span data-token="uiBracket1">[</span>
+  <span data-token="text">  level 2 </span><span data-token="uiBracket2">[</span>
+    <span data-token="text">    level 3 </span><span data-token="uiBracket3">[</span>
+      <span data-token="text">      level 4 </span><span data-token="uiBracket4">[</span>
+        <span data-token="text">        level 5 </span><span data-token="uiBracket5">[</span>
+          <span data-token="text">          level 6 </span><span data-token="uiBracket6">[</span><span data-token="text"> ... </span><span data-token="uiBracket6">]</span>
+        <span data-token="uiBracket5">]</span>
+      <span data-token="uiBracket4">]</span>
+    <span data-token="uiBracket3">]</span>
+  <span data-token="uiBracket2">]</span>
+<span data-token="uiBracket1">]</span>
+`;

--- a/webview/snippets/json.ts
+++ b/webview/snippets/json.ts
@@ -1,0 +1,21 @@
+export const jsonSnippet = `
+<span data-token="punctuation">{</span>
+  <span data-token="jsonLvl0">"level_0"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+    <span data-token="jsonLvl1">"level_1"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+      <span data-token="jsonLvl2">"level_2"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+        <span data-token="jsonLvl3">"level_3"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+          <span data-token="jsonLvl4">"level_4"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+            <span data-token="jsonLvl5">"level_5"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+              <span data-token="jsonLvl6">"level_6"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+                <span data-token="jsonLvl7">"level_7"</span><span data-token="punctuation">:</span> <span data-token="punctuation">{</span>
+                  <span data-token="jsonLvl8">"level_8"</span><span data-token="punctuation">:</span> <span data-token="string">"value"</span>
+                <span data-token="punctuation">}</span>
+              <span data-token="punctuation">}</span>
+            <span data-token="punctuation">}</span>
+          <span data-token="punctuation">}</span>
+        <span data-token="punctuation">}</span>
+      <span data-token="punctuation">}</span>
+    <span data-token="punctuation">}</span>
+  <span data-token="punctuation">}</span>
+<span data-token="punctuation">}</span>
+`;

--- a/webview/style.css
+++ b/webview/style.css
@@ -192,6 +192,10 @@ section.card.danger-zone button.reset-all-button:active::before {
   align-items: center;
 }
 
+#settings-container.view-brackets {
+  grid-template-columns: auto 1fr;
+}
+
 label {
   font-weight: 500;
   color: var(--vscode-description-foreground);
@@ -519,4 +523,21 @@ select:focus,
   background-color: var(--danger-color);
   color: #ffffff;
   border-color: var(--danger-color);
+}
+
+#language-select,
+#settings-view-select {
+  height: calc(var(--control-height) - 10px);
+  padding: 0 30px 0 12px;
+  min-width: 120px;
+  background-color: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border);
+  border-radius: calc(var(--radius) - 4px);
+  color: var(--vscode-input-foreground);
+  font-weight: 500;
+}
+
+#language-select:hover,
+#settings-view-select:hover {
+  border-color: var(--dynamic-accent-color);
 }


### PR DESCRIPTION
Implements a new dropdown in the Customization UI that allows users to switch between three distinct views: Syntax, Brackets, and JSON.

This feature enhances user experience by organizing the settings into logical categories, each with its own dedicated live code preview.

- Adds new snippets for bracket and JSON colorization.
- Updates the ConfigurationService to provide data for the new views.
- Implements the necessary logic in the webview to dynamically render the correct settings and update the preview pane.
- Fixes a CSS layout bug in the "Brackets" view and updates the corresponding unit tests to reflect the new data structure.