### PR TITLE
refactor(types): create shared type contract for webview

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,6 +10,7 @@ assets/images/preview/**
 assets/images/screenshots/**
 node_modules/**
 test/**
+types/**
 coverage/**
 out/
 build.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # Changelog
 
-## [1.6.3] - 2025-08-26
+## [1.6.3] - 2025-08-27
 
 - **Feature**: Added `.dockerignore` file
 - **Feature**: The hex code input fields for syntax colors in the Customization UI are now fully interactive. Users can type or paste a hex code, including an 8-digit code with transparency, and the color picker, alpha slider, and live preview will update in real-time.
 - **Feature**: The Customization UI now features a view selector to switch between "Syntax", "Brackets", and "JSON" settings. This organizes the panel and provides dedicated live previews for each category.
 - **Feature**: Added unit tests for the webview.
-- **Improvement**: Cached github workflow for the npm dependencies and docker image so that the pipline is significant faster.
-- **Improvement**: Docker caching for github actions.
+- **Improvement**: Cached github workflow for the npm dependencies and docker image so that the pipline is faster.
+- **Internal Refactor**: Centralized the type definitions for communication between the extension and the Customization UI into a single, shared `types/webview.ts` file. This creates a stricter and more maintainable contract, reducing code duplication and improving overall reliability.
+- **Chore**: Removed an unused import from the `WebviewManager` to improve code cleanliness.
 - **Fix**: Updated the extension's configuration schema (package.json). VS Code will now correctly validate 8-digit hex codes with alpha channels when a user edits their settings.json manually.
 - **Fix**: Corrected a CSS grid layout issue that caused the bracket color settings to be displayed in a disorganized manner.
 - **Fix**: Updated the webview unit tests to align with the new data structures, resolving a test failure caused by the recent feature addition.
+- - **Fix**: Updated the unit and integration tests (`SettingsPanel.test.ts`, `WebviewManager.test.ts`) to use the new shared type definitions, resolving all compilation errors and ensuring the test suite passes.
 
 ## [1.6.2] - 2025-08-25
 

--- a/local-ci.sh
+++ b/local-ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This is a linux script which works for me on fedora kde 
+# This is a linux script which works for me on fedora kde
 
 set -euo pipefail
 

--- a/src/SettingsPanel.ts
+++ b/src/SettingsPanel.ts
@@ -7,33 +7,7 @@ import * as vscode from "vscode";
 import * as C from "./constants";
 import { WebviewManager } from "./WebviewManager";
 import { ConfigurationService } from "./ConfigurationService";
-
-// #region Webview Message Types
-/** Defines a message to update a font style setting. */
-type UpdateSettingMessage = { command: "updateSetting"; key: string; value: string };
-/** Defines a message to reset a font style setting to its default. */
-type ResetFontStyleMessage = { command: "resetFontStyle"; key: string };
-/** Defines a message to update the active accent color. */
-type UpdateAccentMessage = { command: "updateAccent"; value: string };
-/** Defines a message to update the custom accent color hex code. */
-type UpdateCustomAccentMessage = { command: "updateCustomAccent"; value: string };
-/** Defines a message to update a specific syntax color for a flavor. */
-type UpdateSyntaxColorMessage = { command: "updateSyntaxColor"; flavor: string; key: string; value: string };
-/** Defines a message to reset a specific syntax color for a flavor. */
-type ResetSyntaxColorMessage = { command: "resetSyntaxColor"; flavor: string; key: string };
-/** Defines a message to reset all extension settings to their defaults. */
-type ResetAllMessage = { command: "resetAll" };
-
-/** A discriminated union of all possible messages that can be sent from the webview to the extension. */
-export type WebviewMessage =
-  | UpdateSettingMessage
-  | ResetFontStyleMessage
-  | UpdateAccentMessage
-  | UpdateCustomAccentMessage
-  | UpdateSyntaxColorMessage
-  | ResetSyntaxColorMessage
-  | ResetAllMessage;
-// #endregion
+import { MessageToExtension } from "../types/webview";
 
 /**
  * Manages the state and logic of the settings webview panel.
@@ -68,9 +42,9 @@ export class SettingsPanel {
 
   /**
    * Handles incoming messages from the webview panel.
-   * @param {WebviewMessage} message The deserialized message object sent from the webview.
+   * @param {MessageToExtension} message The deserialized message object sent from the webview.
    */
-  public async _handleMessage(message: WebviewMessage) {
+  public async _handleMessage(message: MessageToExtension) {
     // The 'command' property is used as a discriminator for the message type.
     // TypeScript correctly infers the shape of 'message' in each case block.
     switch (message.command) {

--- a/src/WebviewManager.ts
+++ b/src/WebviewManager.ts
@@ -7,14 +7,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import * as C from "./constants";
-import { WebviewMessage } from "./SettingsPanel";
-import { WebViewSettings } from "./ConfigurationService";
-
-/** Defines the shape of messages sent from the extension *to* the webview. */
-export type MessageToWebview = {
-  command: "loadSettings";
-  settings: WebViewSettings;
-};
+import { MessageToExtension, MessageToWebview } from "../types/webview";
 
 /**
  * Manages the lifecycle and communication of the Calmppuccin settings webview panel.
@@ -31,9 +24,9 @@ export class WebviewManager {
   /**
    * Creates a new WebviewManager instance. This is private to enforce the singleton pattern.
    * @param {vscode.ExtensionContext} context The extension's context.
-   * @param {(message: WebviewMessage) => void} messageHandler The callback function to handle messages received from the webview.
+   * @param {(message: MessageToExtension) => void} messageHandler The callback function to handle messages received from the webview.
    */
-  private constructor(context: vscode.ExtensionContext, messageHandler: (message: WebviewMessage) => void) {
+  private constructor(context: vscode.ExtensionContext, messageHandler: (message: MessageToExtension) => void) {
     this._panel = vscode.window.createWebviewPanel(
       C.WEBVIEW_COMMANDS.WEBVIEW_ID,
       C.WEBVIEW_COMMANDS.WEBVIEW_TITLE,
@@ -59,12 +52,12 @@ export class WebviewManager {
   /**
    * The static method to either create a new webview panel or show the existing one.
    * @param {vscode.ExtensionContext} context The extension's context.
-   * @param {(message: WebviewMessage) => void} messageHandler The callback for messages from the webview.
+   * @param {(message: MessageToExtension) => void} messageHandler The callback for messages from the webview.
    * @param {() => void} [onReveal] An optional callback to run when an existing panel is revealed.
    */
   public static createOrShow(
     context: vscode.ExtensionContext,
-    messageHandler: (message: WebviewMessage) => void,
+    messageHandler: (message: MessageToExtension) => void,
     onReveal?: () => void
   ) {
     if (WebviewManager.currentPanel) {

--- a/test/integration/SettingsPanel.test.ts
+++ b/test/integration/SettingsPanel.test.ts
@@ -5,7 +5,9 @@
  */
 
 import * as vscode from "vscode";
-import { SettingsPanel, WebviewMessage } from "../../src/SettingsPanel";
+import { SettingsPanel } from "../../src/SettingsPanel";
+// Import the shared types from their new, correct location.
+import { MessageToExtension as WebviewMessage } from "../../types/webview";
 import { ConfigurationService } from "../../src/ConfigurationService";
 import * as C from "../../src/constants";
 

--- a/test/unit/WebviewManager.test.ts
+++ b/test/unit/WebviewManager.test.ts
@@ -6,8 +6,9 @@
 
 import * as vscode from "vscode";
 import * as fs from "fs";
-// Import the class and necessary types to be tested.
-import { WebviewManager, MessageToWebview } from "../../src/WebviewManager";
+// Import the shared types from their new, correct location.
+import { MessageToWebview } from "../../types/webview";
+import { WebviewManager } from "../../src/WebviewManager";
 import * as C from "../../src/constants";
 
 // --- Mocking Dependencies ---

--- a/types/webview.ts
+++ b/types/webview.ts
@@ -1,0 +1,50 @@
+/**
+ * @file This file defines the strict, shared contract for communication
+ * between the VS Code extension host (backend) and the settings webview (frontend).
+ */
+
+// #region Payloads & Data Structures
+
+/** A single setting item for the webview. */
+export interface WebviewSetting {
+  key: string;
+  fontStyle?: string;
+  color?: string;
+  defaultColor: string;
+}
+
+/** The complete data payload sent from the extension to the webview upon loading. */
+export interface SettingsPayload {
+  activeFlavor: string;
+  syntaxSettings: WebviewSetting[];
+  bracketSettings: WebviewSetting[];
+  jsonSettings: WebviewSetting[];
+  currentAccent: string;
+  accentOptions: string[];
+  customAccentColor: string;
+  activeThemeBackgroundColor: string;
+  accentColorPalettes: { [key: string]: string };
+  defaultFontStyles: { [key: string]: string };
+}
+
+// #endregion
+
+// #region Message Contracts
+
+/** A discriminated union of all possible messages that can be sent FROM the webview TO the extension. */
+export type MessageToExtension =
+  | { command: "updateSetting"; key: string; value: string }
+  | { command: "resetFontStyle"; key: string }
+  | { command: "updateAccent"; value: string }
+  | { command: "updateCustomAccent"; value: string }
+  | { command: "updateSyntaxColor"; flavor: string; key: string; value: string }
+  | { command: "resetSyntaxColor"; flavor: string; key: string }
+  | { command: "resetAll" };
+
+/** A discriminated union of all possible messages that can be sent FROM the extension TO the webview. */
+export type MessageToWebview = {
+  command: "loadSettings";
+  settings: SettingsPayload;
+};
+
+// #endregion

--- a/webview/main.ts
+++ b/webview/main.ts
@@ -4,49 +4,8 @@
  */
 
 import { codeSnippets } from "./snippets";
-
-// #region Type Definitions
-// These types are duplicated from the extension's backend to create a strict, type-safe contract
-// for communication between the webview (frontend) and the extension host (backend).
-
-/** A single setting item for the webview. */
-type WebviewSetting = {
-  key: string;
-  fontStyle?: string;
-  color?: string;
-  defaultColor: string;
-};
-
-/** The message payload received from the extension when settings are loaded. */
-type SettingsPayload = {
-  activeFlavor: string;
-  syntaxSettings: WebviewSetting[];
-  bracketSettings: WebviewSetting[];
-  jsonSettings: WebviewSetting[];
-  currentAccent: string;
-  accentOptions: string[];
-  customAccentColor: string;
-  activeThemeBackgroundColor: string;
-  accentColorPalettes: { [key: string]: string };
-  defaultFontStyles: { [key: string]: string };
-};
-
-/** A discriminated union of all possible messages that can be received *from* the extension. */
-type MessageFromExtension = {
-  command: "loadSettings";
-  settings: SettingsPayload;
-};
-
-/** A discriminated union of all possible messages that can be sent *to* the extension. */
-type MessageToExtension =
-  | { command: "updateSetting"; key: string; value: string }
-  | { command: "resetFontStyle"; key: string }
-  | { command: "updateAccent"; value: string }
-  | { command: "updateCustomAccent"; value: string }
-  | { command: "updateSyntaxColor"; flavor: string; key: string; value: string }
-  | { command: "resetSyntaxColor"; flavor: string; key: string }
-  | { command: "resetAll" };
-// #endregion
+// Import the shared types from the new central location.
+import { SettingsPayload, MessageToWebview, MessageToExtension, WebviewSetting } from "../types/webview";
 
 /**
  * @interface VsCodeApi
@@ -223,7 +182,7 @@ export class UIManager {
     });
 
     // Primary listener for messages coming from the VS Code extension host.
-    window.addEventListener("message", (event: MessageEvent<MessageFromExtension>) => {
+    window.addEventListener("message", (event: MessageEvent<MessageToWebview>) => {
       const message = event.data;
       if (message.command === COMMANDS.LOAD_SETTINGS) {
         this.populateAllSettings(message.settings);


### PR DESCRIPTION
Centralizes all type definitions used for communication between the extension host and the webview into a new `types/webview.ts` file.

This creates a single source of truth for the data contract, reducing code duplication and improving maintainability.

- Removes duplicated type definitions from `SettingsPanel.ts` and `webview/main.ts`.
- Updates all relevant source files and test files to import from the new shared location.
- Fixes all test suite compilation errors that arose from the refactoring.