### PR TITLE
feat(customization): Add UI color customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## [1.7.1] - 2025-08-30
+## [1.7.1] - 2025-09-04
 
+- **Feature**: Added UI color customization. Users can now change the `base`, `mantle`, and `crust` colors for each theme flavor via the new "UI" tab in the customization panel.
+- **Feature**: The Customization UI now includes a new live preview that visually represents the core VS Code layout, allowing users to see their `base`, `mantle`, and `crust` color changes instantly.
+- **Improvement**: The editor minimap background is now derived from the `crust` color with transparency, ensuring it always stays in sync with the editor's background.
+- **Internal**: Updated unit and integration tests to cover the new UI customization functionality, ensuring stability and correctness.
 - **Improvement**: Updated github workflow
 
 ## [1.7.0] - 2025-08-27

--- a/build.ts
+++ b/build.ts
@@ -8,7 +8,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import palette, { IPalettes } from "./src/palettes";
 import * as C from "./src/constants";
-import { IFontStyles, ISyntaxOverrides } from "./src/ConfigurationService";
+import { IFontStyles, ISyntaxOverrides, IUiOverrides } from "./src/ConfigurationService";
 
 const THEME_DIR = path.resolve(__dirname, "..", C.THEMES_DIR);
 const TEMPLATE_PATH = path.resolve(__dirname, "..", C.SRC_DIR, C.TEMPLATE_FILE);
@@ -19,12 +19,14 @@ const FLAVORS = Object.keys(palette) as Array<keyof IPalettes>;
  * @param {string} accentIdentifier The name of the accent color (e.g., "sapphire") or a custom hex code.
  * @param {IFontStyles} editorSettings The user's configured font style settings.
  * @param {ISyntaxOverrides} syntaxOverrides The user's configured syntax color overrides.
+ * @param {IUiOverrides} uiOverrides The user's configured UI color overrides.
  * @returns {Promise<void>} A promise that resolves when all theme files have been written to disk.
  */
 export async function buildAllFlavors(
   accentIdentifier: string,
   editorSettings: IFontStyles,
-  syntaxOverrides: ISyntaxOverrides
+  syntaxOverrides: ISyntaxOverrides,
+  uiOverrides: IUiOverrides
 ): Promise<void> {
   // Ensure the output directory is clean and ready.
   await fs.emptyDir(THEME_DIR);
@@ -34,9 +36,10 @@ export async function buildAllFlavors(
   // Iterate over each flavor (latte, frappe, mocha, etc.) to generate a theme for it.
   for (const flavor of FLAVORS) {
     const basePalette = palette[flavor];
-    const flavorOverrides = syntaxOverrides[flavor] || {};
+    const flavorSyntaxOverrides = syntaxOverrides[flavor] || {};
+    const flavorUiOverrides = uiOverrides[flavor] || {};
     // Merge the base flavor palette with any user-defined color overrides.
-    const finalPalette = { ...basePalette, ...flavorOverrides };
+    const finalPalette = { ...basePalette, ...flavorSyntaxOverrides, ...flavorUiOverrides };
 
     // Resolve the accent color. If it's a hex code, use it directly. Otherwise, look it up in the palette.
     const accentColor = accentIdentifier.startsWith("#")
@@ -98,5 +101,5 @@ function getDefaultFontStyles(): IFontStyles {
  */
 if (require.main === module) {
   const defaultFontStyles = getDefaultFontStyles();
-  buildAllFlavors(C.DEFAULT_ACCENT, defaultFontStyles, {});
+  buildAllFlavors(C.DEFAULT_ACCENT, defaultFontStyles, {}, {});
 }

--- a/extension.ts
+++ b/extension.ts
@@ -73,7 +73,8 @@ export function activate(context: vscode.ExtensionContext) {
       const accentValue = ConfigurationService.getAccent();
       const fontStyles = ConfigurationService.getFontStyles();
       const syntaxOverrides = ConfigurationService.getSyntaxOverrides();
-      await buildAllFlavors(accentValue, fontStyles, syntaxOverrides);
+      const uiOverrides = ConfigurationService.getUiOverrides();
+      await buildAllFlavors(accentValue, fontStyles, syntaxOverrides, uiOverrides);
       const selection = await vscode.window.showInformationMessage(C.INFO_MESSAGE, C.RELOAD_ACTION);
       if (selection === C.RELOAD_ACTION) {
         vscode.commands.executeCommand(C.RELOAD_COMMAND_ID);
@@ -120,7 +121,8 @@ export function activate(context: vscode.ExtensionContext) {
         event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_ACCENT}`) ||
         event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_FONT_STYLES}`) ||
         event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_CUSTOM_ACCENT}`) ||
-        event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_SYNTAX_OVERRIDES}`)
+        event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_SYNTAX_OVERRIDES}`) ||
+        event.affectsConfiguration(`${C.EXTENSION_NAMESPACE}.${C.CONFIG_KEY_UI_OVERRIDES}`)
       ) {
         vscode.commands.executeCommand(C.REGENERATE_COMMAND_ID);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calmppuccin-vscode",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calmppuccin-vscode",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Calmppuccin",
   "description": "Calmppuccin is a visually refined theme for Visual Studio Code, designed to offer a harmonious coding experience. Inspired by the popular Catppuccin theme, Calmppuccin takes the beloved pastel palette and transforms it into a gentler, less intense version, perfect for long coding sessions without eye strain.",
   "icon": "assets/images/logo/icon.png",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "publisher": "kenan-salar",
   "license": "MIT",
   "repository": {
@@ -1027,6 +1027,36 @@
                   "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$",
                   "patternErrorMessage": "Please enter a valid 6 or 8-digit hex color code (e.g., #RRGGBB or #RRGGBBAA).",
                   "description": "Overrides the color for the ninth-level JSON keys."
+                }
+              }
+            }
+          }
+        },
+        "calmppuccin.uiOverrides": {
+          "type": "object",
+          "default": {},
+          "description": "Override specific UI colors for each Calmppuccin flavor. Use the Customization UI for a better experience.",
+          "patternProperties": {
+            "^(latte|frappe|macchiato|mocha|nitro-cold-brew|oledppuccin)$": {
+              "type": "object",
+              "properties": {
+                "base": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6})$",
+                  "patternErrorMessage": "Please enter a valid 6-digit hex color code (e.g., #RRGGBB).",
+                  "description": "Overrides the color for the base background."
+                },
+                "mantle": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6})$",
+                  "patternErrorMessage": "Please enter a valid 6-digit hex color code (e.g., #RRGGBB).",
+                  "description": "Overrides the color for the mantle background."
+                },
+                "crust": {
+                  "type": "string",
+                  "pattern": "^#([A-Fa-f0-9]{6})$",
+                  "patternErrorMessage": "Please enter a valid 6-digit hex color code (e.g., #RRGGBB).",
+                  "description": "Overrides the color for the crust background."
                 }
               }
             }

--- a/src/ConfigurationService.ts
+++ b/src/ConfigurationService.ts
@@ -7,7 +7,12 @@
 import * as vscode from "vscode";
 import * as C from "./constants";
 import palettes, { IPalettes as IPalettes } from "./palettes";
-import { CUSTOMIZABLE_BRACKET_KEYS, CUSTOMIZABLE_JSON_KEYS, CUSTOMIZABLE_SYNTAX_KEYS } from "./constants";
+import {
+  CUSTOMIZABLE_BRACKET_KEYS,
+  CUSTOMIZABLE_JSON_KEYS,
+  CUSTOMIZABLE_SYNTAX_KEYS,
+  CUSTOMIZABLE_UI_KEYS,
+} from "./constants";
 import { ISettingsPayload, IWebviewSetting } from "../types/webview";
 
 /** Defines the shape of the font styles configuration object in settings.json. */
@@ -17,6 +22,13 @@ export interface IFontStyles {
 
 /** Defines the shape of the syntax color overrides object in settings.json. */
 export interface ISyntaxOverrides {
+  [flavor: string]: {
+    [token: string]: string;
+  };
+}
+
+/** Defines the shape of the UI color overrides object in settings.json. */
+export interface IUiOverrides {
   [flavor: string]: {
     [token: string]: string;
   };
@@ -80,6 +92,14 @@ export class ConfigurationService {
    */
   public static getSyntaxOverrides(): ISyntaxOverrides {
     return this.config.get<ISyntaxOverrides>(C.CONFIG_KEY_SYNTAX_OVERRIDES, {});
+  }
+
+  /**
+   * Gets the user-defined UI color overrides from settings.json.
+   * @returns {IUiOverrides} The UI overrides object. Returns an empty object if not set.
+   */
+  public static getUiOverrides(): IUiOverrides {
+    return this.config.get<IUiOverrides>(C.CONFIG_KEY_UI_OVERRIDES, {});
   }
 
   /**
@@ -158,11 +178,44 @@ export class ConfigurationService {
   }
 
   /**
+   * Updates a specific UI color override for a given flavor.
+   * @param {string} flavor The theme flavor.
+   * @param {string} key The UI key (e.g., "base").
+   * @param {string} value The new hex color value.
+   */
+  public static async updateUiColor(flavor: string, key: string, value: string) {
+    const overrides: IUiOverrides = JSON.parse(JSON.stringify(this.getUiOverrides()));
+    if (!overrides[flavor]) {
+      overrides[flavor] = {};
+    }
+    overrides[flavor][key] = value;
+    await this.config.update(C.CONFIG_KEY_UI_OVERRIDES, overrides, vscode.ConfigurationTarget.Global);
+  }
+
+  /**
+   * Resets a specific UI color override for a given flavor.
+   * @param {string} flavor The theme flavor.
+   * @param {string} key The UI key.
+   */
+  public static async resetUiColor(flavor: string, key: string) {
+    const overrides: IUiOverrides = JSON.parse(JSON.stringify(this.getUiOverrides()));
+    if (overrides[flavor]?.[key]) {
+      delete overrides[flavor][key];
+      if (Object.keys(overrides[flavor]).length === 0) {
+        delete overrides[flavor];
+      }
+      const finalOverrides = Object.keys(overrides).length === 0 ? undefined : overrides;
+      await this.config.update(C.CONFIG_KEY_UI_OVERRIDES, finalOverrides, vscode.ConfigurationTarget.Global);
+    }
+  }
+
+  /**
    * Resets all user-defined settings for the extension to their default values.
    */
   public static async resetAll() {
     await this.config.update(C.CONFIG_KEY_FONT_STYLES, undefined, vscode.ConfigurationTarget.Global);
     await this.config.update(C.CONFIG_KEY_SYNTAX_OVERRIDES, undefined, vscode.ConfigurationTarget.Global);
+    await this.config.update(C.CONFIG_KEY_UI_OVERRIDES, undefined, vscode.ConfigurationTarget.Global);
     await this.config.update(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT, vscode.ConfigurationTarget.Global);
   }
 
@@ -201,6 +254,7 @@ export class ConfigurationService {
     const activeFlavor = this.getActiveFlavor();
     const fontStyles = this.getFontStyles();
     const syntaxOverrides = this.getSyntaxOverrides();
+    const uiOverrides = this.getUiOverrides();
     const currentAccent = this.config.get<string>(C.CONFIG_KEY_ACCENT, C.DEFAULT_ACCENT);
     const customAccentColor = this.config.get<string>(C.CONFIG_KEY_CUSTOM_ACCENT, C.DEFAULT_CUSTOM_ACCENT);
 
@@ -212,7 +266,8 @@ export class ConfigurationService {
       [];
 
     const defaultPalette = palettes[activeFlavor];
-    const overridePalette = syntaxOverrides[activeFlavor] || {};
+    const overrideSyntaxPalette = syntaxOverrides[activeFlavor] || {};
+    const overrideUiPalette = uiOverrides[activeFlavor] || {};
     const activeThemeBackgroundColor = defaultPalette.crust;
 
     const accentColorPalettes = accentOptions.reduce((acc: { [key: string]: string }, option: string) => {
@@ -226,7 +281,7 @@ export class ConfigurationService {
       (key): IWebviewSetting => ({
         key: key,
         fontStyle: fontStyles[`${key}FontStyle`] ?? "none",
-        color: overridePalette[key] || defaultPalette[key],
+        color: overrideSyntaxPalette[key] || defaultPalette[key],
         defaultColor: defaultPalette[key],
       })
     );
@@ -234,7 +289,7 @@ export class ConfigurationService {
     const bracketSettings = CUSTOMIZABLE_BRACKET_KEYS.map(
       (key): IWebviewSetting => ({
         key: key,
-        color: overridePalette[key] || defaultPalette[key],
+        color: overrideSyntaxPalette[key] || defaultPalette[key],
         defaultColor: defaultPalette[key],
       })
     );
@@ -243,7 +298,15 @@ export class ConfigurationService {
       (key): IWebviewSetting => ({
         key: key,
         fontStyle: fontStyles[`${key}FontStyle`] ?? "none",
-        color: overridePalette[key] || defaultPalette[key],
+        color: overrideSyntaxPalette[key] || defaultPalette[key],
+        defaultColor: defaultPalette[key],
+      })
+    );
+
+    const uiSettings = CUSTOMIZABLE_UI_KEYS.map(
+      (key): IWebviewSetting => ({
+        key: key,
+        color: overrideUiPalette[key] || defaultPalette[key],
         defaultColor: defaultPalette[key],
       })
     );
@@ -253,6 +316,7 @@ export class ConfigurationService {
       syntaxSettings,
       bracketSettings,
       jsonSettings,
+      uiSettings,
       currentAccent,
       accentOptions,
       customAccentColor,

--- a/src/SettingsPanel.ts
+++ b/src/SettingsPanel.ts
@@ -66,6 +66,12 @@ export class SettingsPanel {
       case C.WEBVIEW_COMMANDS.RESET_SYNTAX_COLOR:
         await ConfigurationService.resetSyntaxColor(message.flavor, message.key);
         return;
+      case C.WEBVIEW_COMMANDS.UPDATE_UI_COLOR:
+        await ConfigurationService.updateUiColor(message.flavor, message.key, message.value);
+        return;
+      case C.WEBVIEW_COMMANDS.RESET_UI_COLOR:
+        await ConfigurationService.resetUiColor(message.flavor, message.key);
+        return;
       case C.WEBVIEW_COMMANDS.RESET_ALL:
         await ConfigurationService.resetAll();
         this._update();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export const CATPPUCCIN_ICON_PACK_ID = "catppuccin-";
 export const PANEL_IS_OPEN_KEY = "calmppuccin.panelIsOpen";
 export const CONFIG_KEY_FONT_STYLES = "fontStyles";
 export const CONFIG_KEY_SYNTAX_OVERRIDES = "syntaxOverrides";
+export const CONFIG_KEY_UI_OVERRIDES = "uiOverrides";
 export const CUSTOMIZE_COMMAND_ID = "calmppuccin.customize";
 
 /** Constants used in the `build.ts` script for theme generation. */
@@ -49,6 +50,8 @@ export const WEBVIEW_COMMANDS = {
   UPDATE_CUSTOM_ACCENT: "updateCustomAccent",
   UPDATE_SYNTAX_COLOR: "updateSyntaxColor",
   RESET_SYNTAX_COLOR: "resetSyntaxColor",
+  UPDATE_UI_COLOR: "updateUiColor",
+  RESET_UI_COLOR: "resetUiColor",
   RESET_ALL: "resetAll",
   LOAD_SETTINGS: "loadSettings",
   WEBVIEW_ID: "calmppuccinSettings",
@@ -112,3 +115,4 @@ export const CUSTOMIZABLE_JSON_KEYS = [
   "jsonLvl7",
   "jsonLvl8",
 ];
+export const CUSTOMIZABLE_UI_KEYS = ["base", "mantle", "crust"];

--- a/src/palettes/frappe.ts
+++ b/src/palettes/frappe.ts
@@ -110,7 +110,6 @@ export default {
   uiMergeCurrentHeaderBackground: "#95ce8f66",
   uiMergeIncomingContentBackground: "#79a0df33",
   uiMergeIncomingHeaderBackground: "#79a0df66",
-  uiMinimapBackground: "#2f33449d",
   uiMatchHighlight: "#7ac3cf4d",
   uiMinimapSelectionHighlight: "#585b70bf",
   uiMinimapWarning: "#e2a47dbf",

--- a/src/palettes/latte.ts
+++ b/src/palettes/latte.ts
@@ -110,7 +110,6 @@ export default {
   uiMergeCurrentHeaderBackground: "#5e617ed3",
   uiMergeIncomingContentBackground: "#1c8da133",
   uiMergeIncomingHeaderBackground: "#1c8da166",
-  uiMinimapBackground: "#e9eaee9d",
   uiMatchHighlight: "#7ac3cf4d",
   uiMinimapSelectionHighlight: "#5e617ebf",
   uiMinimapWarning: "#fe640bbf",

--- a/src/palettes/macchiato.ts
+++ b/src/palettes/macchiato.ts
@@ -111,7 +111,6 @@ export default {
   uiMergeCurrentHeaderBackground: "#95ce8f66",
   uiMergeIncomingContentBackground: "#799fdb33",
   uiMergeIncomingHeaderBackground: "#799fdb66",
-  uiMinimapBackground: "#24273a9d",
   uiMatchHighlight: "#7ac3cf4d",
   uiMinimapSelectionHighlight: "#585b70bf",
   uiMinimapWarning: "#e2a47dbf",

--- a/src/palettes/mocha.ts
+++ b/src/palettes/mocha.ts
@@ -110,7 +110,6 @@ export default {
   uiMergeCurrentHeaderBackground: "#95ce8f66",
   uiMergeIncomingContentBackground: "#789cd633",
   uiMergeIncomingHeaderBackground: "#789cd666",
-  uiMinimapBackground: "#1d1d2c9d",
   uiMatchHighlight: "#7ac3cf4d",
   uiMinimapSelectionHighlight: "#585b70bf",
   uiMinimapWarning: "#e2a47dbf",

--- a/src/palettes/nitro-cold-brew.ts
+++ b/src/palettes/nitro-cold-brew.ts
@@ -111,7 +111,6 @@ export default {
   uiMergeCurrentHeaderBackground: "#91c78b66",
   uiMergeIncomingContentBackground: "#7698cf33",
   uiMergeIncomingHeaderBackground: "#7698cf66",
-  uiMinimapBackground: "#1818259d",
   uiMatchHighlight: "#78bfca4d",
   uiMinimapSelectionHighlight: "#4f5264bf",
   uiMinimapWarning: "#dba07bbf",

--- a/src/palettes/oledppuccin.ts
+++ b/src/palettes/oledppuccin.ts
@@ -111,7 +111,6 @@ export default {
   uiMergeCurrentHeaderBackground: "#86b68066",
   uiMergeIncomingContentBackground: "#708fc033",
   uiMergeIncomingHeaderBackground: "#708fc066",
-  uiMinimapBackground: "#0b0b119d",
   uiMatchHighlight: "#78bfca4d",
   uiMinimapSelectionHighlight: "#31333fbf",
   uiMinimapWarning: "#c99474bf",

--- a/src/template.json
+++ b/src/template.json
@@ -350,7 +350,7 @@
     "merge.incomingContentBackground": "{{uiMergeIncomingContentBackground}}",
     "merge.incomingHeaderBackground": "{{uiMergeIncomingHeaderBackground}}",
 
-    "minimap.background": "{{uiMinimapBackground}}",
+    "minimap.background": "{{crust}}9d",
     "minimap.findMatchHighlight": "{{uiMatchHighlight}}",
     "minimap.selectionHighlight": "{{uiMinimapSelectionHighlight}}",
     "minimap.selectionOccurrenceHighlight": "{{uiMinimapSelectionHighlight}}",

--- a/test/integration/SettingsPanel.test.ts
+++ b/test/integration/SettingsPanel.test.ts
@@ -160,6 +160,51 @@ describe("SettingsPanel Integration Tests", () => {
   });
 
   /**
+   * @description Tests that an 'updateUiColor' message from the webview
+   * correctly triggers the ConfigurationService.updateUiColor method.
+   */
+  it("should call updateUiColor on the ConfigurationService when receiving an updateUiColor message", async () => {
+    // 1. Arrange
+    const panel = new (SettingsPanel as any)(mockContext);
+    const updateUiColorSpy = jest.spyOn(ConfigurationService, "updateUiColor");
+    const mockMessage: WebviewMessage = {
+      command: "updateUiColor",
+      flavor: "latte",
+      key: "base",
+      value: "#ffffff",
+    };
+
+    // 2. Act
+    await panel._handleMessage(mockMessage);
+
+    // 3. Assert
+    expect(updateUiColorSpy).toHaveBeenCalledTimes(1);
+    expect(updateUiColorSpy).toHaveBeenCalledWith("latte", "base", "#ffffff");
+  });
+
+  /**
+   * @description Tests that a 'resetUiColor' message from the webview
+   * correctly triggers the ConfigurationService.resetUiColor method.
+   */
+  it("should call resetUiColor on the ConfigurationService when receiving a resetUiColor message", async () => {
+    // 1. Arrange
+    const panel = new (SettingsPanel as any)(mockContext);
+    const resetUiColorSpy = jest.spyOn(ConfigurationService, "resetUiColor");
+    const mockMessage: WebviewMessage = {
+      command: "resetUiColor",
+      flavor: "mocha",
+      key: "crust",
+    };
+
+    // 2. Act
+    await panel._handleMessage(mockMessage);
+
+    // 3. Assert
+    expect(resetUiColorSpy).toHaveBeenCalledTimes(1);
+    expect(resetUiColorSpy).toHaveBeenCalledWith("mocha", "crust");
+  });
+
+  /**
    * @description Tests that a 'resetAll' message from the webview
    * correctly triggers the ConfigurationService.resetAll method.
    * @precondition The ConfigurationService is mocked.

--- a/test/unit/build.test.ts
+++ b/test/unit/build.test.ts
@@ -44,7 +44,7 @@ describe("Build Script Unit Tests", () => {
     (fs.writeJson as unknown as jest.Mock).mockResolvedValue(undefined);
 
     // 2. Act
-    await buildAllFlavors("sapphire", mockFontStyles, {});
+    await buildAllFlavors("sapphire", mockFontStyles, {}, {});
 
     // 3. Assert
     expect(fs.writeJson).toHaveBeenCalled();
@@ -86,14 +86,12 @@ describe("Build Script Unit Tests", () => {
 
     // 2. Act: Run the build process with a known accent color.
     // We'll use the 'mocha' flavor and the 'mauve' accent for this test.
-    await buildAllFlavors("mauve", {}, {});
+    await buildAllFlavors("mauve", {}, {}, {});
 
     // 3. Assert: Verify the output for the Mocha theme.
 
     // Find the specific call to writeJson for the 'mocha' theme file.
-    const mochaCall = (fs.writeJson as jest.Mock).mock.calls.find(call =>
-      call[0].includes('mocha')
-    );
+    const mochaCall = (fs.writeJson as jest.Mock).mock.calls.find((call) => call[0].includes("mocha"));
 
     expect(mochaCall).toBeDefined();
 
@@ -105,7 +103,7 @@ describe("Build Script Unit Tests", () => {
 
     // Verify the solid accent color was replaced correctly.
     expect(writtenJson.colors["statusBar.background"]).toBe(mauveHex);
-    
+
     // Verify the recipe was correctly resolved by concatenating the hex value
     // (without the '#') and the transparency value.
     expect(writtenJson.colors["statusBar.dropBorder"]).toBe(`${mauveHex}2f`);

--- a/test/unit/webview.test.ts
+++ b/test/unit/webview.test.ts
@@ -23,6 +23,7 @@ const htmlFixture = `
   </div>
   <select id="settings-view-select">
     <option value="syntax">Syntax</option>
+    <option value="ui">UI</option>
     <option value="brackets">Brackets</option>
     <option value="json">JSON</option>
   </select>
@@ -49,6 +50,11 @@ const mockSettingsPayload = {
   ],
   bracketSettings: [{ key: "uiBracket1", color: "#6cb3c0", defaultColor: "#6cb3c0" }],
   jsonSettings: [{ key: "jsonLvl0", fontStyle: "none", color: "#8eb4f0", defaultColor: "#8eb4f0" }],
+  uiSettings: [
+    { key: "base", color: "#11111a", defaultColor: "#11111a" },
+    { key: "mantle", color: "#171724", defaultColor: "#171724" },
+    { key: "crust", color: "#1d1d2c", defaultColor: "#1d1d2c" },
+  ],
   currentAccent: "sapphire",
   accentOptions: ["sapphire", "mauve", "custom"],
   customAccentColor: "#89b4fa",
@@ -75,7 +81,7 @@ describe("UIManager Unit Tests", () => {
     // Assert
     const languageSelect = document.getElementById("language-select") as HTMLSelectElement;
     // We filter out brackets and json from the main language selector
-    const expectedOptions = Object.keys(codeSnippets).length - 2;
+    const expectedOptions = Object.keys(codeSnippets).length - 3;
     expect(languageSelect.options.length).toBe(expectedOptions);
     expect(languageSelect.value).toBe("csharp");
 

--- a/types/webview.ts
+++ b/types/webview.ts
@@ -3,8 +3,6 @@
  * between the VS Code extension host (backend) and the settings webview (frontend).
  */
 
-// #region Payloads & Data Structures
-
 /** A single setting item for the webview. */
 export interface IWebviewSetting {
   key: string;
@@ -19,6 +17,7 @@ export interface ISettingsPayload {
   syntaxSettings: IWebviewSetting[];
   bracketSettings: IWebviewSetting[];
   jsonSettings: IWebviewSetting[];
+  uiSettings: IWebviewSetting[];
   currentAccent: string;
   accentOptions: string[];
   customAccentColor: string;
@@ -26,10 +25,6 @@ export interface ISettingsPayload {
   accentColorPalettes: { [key: string]: string };
   defaultFontStyles: { [key: string]: string };
 }
-
-// #endregion
-
-// #region Message Contracts
 
 /** A discriminated union of all possible messages that can be sent FROM the webview TO the extension. */
 export type MessageToExtension =
@@ -39,6 +34,8 @@ export type MessageToExtension =
   | { command: "updateCustomAccent"; value: string }
   | { command: "updateSyntaxColor"; flavor: string; key: string; value: string }
   | { command: "resetSyntaxColor"; flavor: string; key: string }
+  | { command: "updateUiColor"; flavor: string; key: string; value: string }
+  | { command: "resetUiColor"; flavor: string; key: string }
   | { command: "resetAll" };
 
 /** A discriminated union of all possible messages that can be sent FROM the extension TO the webview. */
@@ -46,5 +43,3 @@ export type MessageToWebview = {
   command: "loadSettings";
   settings: ISettingsPayload;
 };
-
-// #endregion

--- a/webview/index.html
+++ b/webview/index.html
@@ -36,6 +36,7 @@
             <div class="language-selector-container">
               <select id="settings-view-select">
                 <option value="syntax">Syntax</option>
+                <option value="ui">UI</option>
                 <option value="brackets">Brackets</option>
                 <option value="json">JSON</option>
               </select>

--- a/webview/main.ts
+++ b/webview/main.ts
@@ -32,6 +32,8 @@ const COMMANDS = {
   UPDATE_CUSTOM_ACCENT: "updateCustomAccent",
   UPDATE_SYNTAX_COLOR: "updateSyntaxColor",
   RESET_SYNTAX_COLOR: "resetSyntaxColor",
+  UPDATE_UI_COLOR: "updateUiColor",
+  RESET_UI_COLOR: "resetUiColor",
   RESET_ALL: "resetAll",
   LOAD_SETTINGS: "loadSettings",
 } as const;
@@ -120,7 +122,7 @@ export class UIManager {
   public initializeEventListeners() {
     // Populate the language selector dropdown and set up its change event.
     for (const lang in codeSnippets) {
-      if (lang !== "brackets" && lang !== "json") {
+      if (lang !== "brackets" && lang !== "json" && lang !== "ui") {
         const option = document.createElement("option");
         option.value = lang;
         option.textContent = lang;
@@ -206,7 +208,14 @@ export class UIManager {
       elements.forEach((el) => {
         const tokenStyle = this.previewState[tokenKey];
         if (tokenStyle.color) {
-          el.style.color = tokenStyle.color;
+          if (["base", "mantle", "crust"].includes(tokenKey)) {
+            el.style.backgroundColor = tokenStyle.color;
+            if (tokenKey === "crust") {
+              this.elements.previewPane.style.backgroundColor = tokenStyle.color;
+            }
+          } else {
+            el.style.color = tokenStyle.color;
+          }
         }
         if (tokenStyle.fontStyle) {
           const style = tokenStyle.fontStyle;
@@ -302,6 +311,12 @@ export class UIManager {
         this.elements.languageSelect.style.display = ""; // Show language selector
         this.elements.languageSelect.value = "csharp";
         this.elements.codePreview.innerHTML = codeSnippets.csharp;
+        break;
+      case "ui":
+        this.elements.settingsContainer.classList.add("view-brackets");
+        this._createSyntaxControls(this.settings.uiSettings, {}, false);
+        this.elements.languageSelect.style.display = "none";
+        this.elements.codePreview.innerHTML = codeSnippets.ui;
         break;
       case "brackets":
         // Add a class to switch to a 2-column layout.
@@ -433,6 +448,11 @@ export class UIManager {
     alphaSlider.min = "0";
     alphaSlider.max = "255";
     alphaSlider.step = "1";
+    const isUiColor = ["base", "mantle", "crust"].includes(key);
+    if (isUiColor) {
+      alphaSlider.style.display = "none";
+      hexInput.maxLength = 7;
+    }
 
     // --- Set initial values from settings ---
     const initialColor = color || defaultColor || "#ffffffff";
@@ -440,7 +460,7 @@ export class UIManager {
     const initialAlphaHex = initialColor.length === 9 ? initialColor.substring(7, 9) : "ff";
     colorInput.value = initialRgb;
     alphaSlider.value = parseInt(initialAlphaHex, 16).toString();
-    hexInput.value = initialColor;
+    hexInput.value = isUiColor ? initialRgb : initialColor;
 
     // --- Helper function to update the UI from the color picker & slider ---
     const updateFromPickers = () => {
@@ -448,7 +468,7 @@ export class UIManager {
       const newAlpha = parseInt(alphaSlider.value);
       const newAlphaHex = newAlpha.toString(16).padStart(2, "0");
 
-      const finalColor = `${newRgb}${newAlphaHex}`;
+      const finalColor = isUiColor ? newRgb : `${newRgb}${newAlphaHex}`;
 
       hexInput.value = finalColor;
       this.previewState[key].color = finalColor;
@@ -457,8 +477,9 @@ export class UIManager {
 
     // --- Helper function to send the final color to the extension backend ---
     const sendFinalColorToVSCode = () => {
+      const command = isUiColor ? COMMANDS.UPDATE_UI_COLOR : COMMANDS.UPDATE_SYNTAX_COLOR;
       this.vscode.postMessage({
-        command: COMMANDS.UPDATE_SYNTAX_COLOR,
+        command: command,
         flavor: this.activeFlavor,
         key,
         value: hexInput.value,
@@ -476,7 +497,8 @@ export class UIManager {
     // --- Add event listener for the text input ---
     hexInput.addEventListener("input", () => {
       const typedValue = hexInput.value;
-      const match = typedValue.match(this.hex8Regex);
+      const regex = isUiColor ? this.hex6Regex : this.hex8Regex;
+      const match = typedValue.match(regex);
 
       if (match) {
         // If the typed value is a valid hex code
@@ -489,7 +511,9 @@ export class UIManager {
 
         // Update the color picker and slider to match the typed input
         colorInput.value = rgb;
-        alphaSlider.value = alphaDecimal.toString();
+        if (!isUiColor) {
+          alphaSlider.value = alphaDecimal.toString();
+        }
 
         // Update the live preview
         this.previewState[key].color = typedValue;
@@ -503,8 +527,9 @@ export class UIManager {
 
     // --- NEW: Send the final value to the backend when the user is done editing ---
     hexInput.addEventListener("change", () => {
+      const regex = isUiColor ? this.hex6Regex : this.hex8Regex;
       // Only send the message if the final value is valid
-      if (this.hex8Regex.test(hexInput.value)) {
+      if (regex.test(hexInput.value)) {
         sendFinalColorToVSCode();
       }
     });
@@ -518,10 +543,11 @@ export class UIManager {
       const defaultAlphaHex = defaultColor.length === 9 ? defaultColor.substring(7, 9) : "ff";
       colorInput.value = defaultRgb;
       alphaSlider.value = parseInt(defaultAlphaHex, 16).toString();
-      hexInput.value = defaultColor;
+      hexInput.value = isUiColor ? defaultRgb : defaultColor;
       this.previewState[key].color = defaultColor;
       this.updatePreviewPane();
-      this.vscode.postMessage({ command: COMMANDS.RESET_SYNTAX_COLOR, flavor: this.activeFlavor, key });
+      const command = isUiColor ? COMMANDS.RESET_UI_COLOR : COMMANDS.RESET_SYNTAX_COLOR;
+      this.vscode.postMessage({ command, flavor: this.activeFlavor, key });
     });
 
     // --- DOM Assembly ---

--- a/webview/snippets.ts
+++ b/webview/snippets.ts
@@ -21,6 +21,7 @@ import { sqlSnippet } from "./snippets/sql";
 import { typescriptSnippet } from "./snippets/typescript";
 import { bracketsSnippet } from "./snippets/brackets";
 import { jsonSnippet } from "./snippets/json";
+import { uiSnippet } from "./snippets/ui";
 
 /**
  * Defines the shape for the code snippets object.
@@ -53,4 +54,5 @@ export const codeSnippets: CodeSnippets = {
   typescript: typescriptSnippet,
   brackets: bracketsSnippet,
   json: jsonSnippet,
+  ui: uiSnippet,
 };

--- a/webview/snippets/ui.ts
+++ b/webview/snippets/ui.ts
@@ -1,0 +1,99 @@
+export const uiSnippet = `
+<style>
+  /* Overall container for the entire preview layout */
+  .ui-layout-wrapper {
+    display: flex;
+    flex-direction: column; /* Stack Title Bar on top of the rest */
+    height: 100%;
+    width: 100%;
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    border-radius: 8px;
+    overflow: hidden;
+    background-color: var(--base-color, #11111a); /* Fallback BG */
+  }
+
+  /* Red Area: Title Bar at the top */
+  .ui-layout-titlebar {
+    flex-shrink: 0;
+    height: 30px; /* Represents the title bar area */
+    background-color: var(--base-color, #11111a);
+    transition: background-color 250ms ease;
+  }
+
+  /* Container for everything below the title bar */
+  .ui-layout-main-area {
+    display: flex;
+    flex-grow: 1; /* Take up remaining vertical space */
+    height: 100%;
+  }
+
+  /* Red Area: Activity Bar on the far left */
+  .ui-layout-activitybar {
+    flex-shrink: 0;
+    width: 48px; /* Standard VS Code activity bar width */
+    background-color: var(--base-color, #11111a);
+    transition: background-color 250ms ease;
+  }
+
+  /* Blue Area: Sidebar next to the activity bar */
+  .ui-layout-sidebar {
+    flex-shrink: 0;
+    width: 150px; /* Visual representation of the sidebar */
+    background-color: var(--mantle-color, #171724);
+    transition: background-color 250ms ease;
+  }
+
+  /* Wrapper for the tab bar and editor pane */
+  .ui-layout-editor-wrapper {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Blue Area: Tab bar above the editor */
+  .ui-layout-tabbar {
+    flex-shrink: 0;
+    height: 35px; /* Standard VS Code tab bar height */
+    background-color: var(--mantle-color, #171724);
+    transition: background-color 250ms ease;
+  }
+
+  /* Green Area: Main editor content area */
+  .ui-layout-editor {
+    flex-grow: 1;
+    background-color: var(--crust-color, #1d1d2c);
+    transition: background-color 250ms ease;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--vscode-editor-foreground);
+    text-align: center;
+    padding: 20px;
+  }
+
+  .ui-layout-editor span {
+    display: block;
+    font-size: 0.85em;
+    opacity: 0.7;
+    margin-top: 4px;
+  }
+</style>
+
+<div class="ui-layout-wrapper">
+  <div class="ui-layout-titlebar" data-token="base"></div>
+  
+  <div class="ui-layout-main-area">
+    <div class="ui-layout-activitybar" data-token="base"></div>
+    
+    <div class="ui-layout-sidebar" data-token="mantle"></div>
+    
+    <div class="ui-layout-editor-wrapper">
+      <div class="ui-layout-tabbar" data-token="mantle"></div>
+      
+      <div class="ui-layout-editor" data-token="crust">
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This introduces a new "UI" view in the customization panel, allowing users to override the core `base`, `mantle`, and `crust` colors for each theme flavor.

Key changes include:
- A new "UI" tab in the settings view with dedicated color pickers.
- A new live preview snippet that visually represents the VS Code layout (Activity Bar, Sidebar, Editor, etc.) to provide instant feedback on color changes.
- The `ConfigurationService` and `SettingsPanel` have been updated to handle getting, setting, and resetting these new `uiOverrides`.
- The theme build process now correctly applies these UI overrides, giving users full control over the theme's core background colors.
- The editor minimap background color is now derived from the `crust` color with transparency for better visual consistency.
- All relevant unit and integration tests have been updated to cover this new functionality.